### PR TITLE
Option to display arrows instead of +~| symbols in tree

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -642,6 +642,9 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeWinSize'|             Sets the window size when the NERD tree is
                                 opened.
 
+|'NERDTreeDirArrows'|           Tells the NERD tree to use arrows instead of
+                                + ~ chars when displaying directories.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -920,6 +923,19 @@ Values: a positive integer.
 Default: 31.
 
 This option is used to change the size of the NERD tree when it is loaded.
+
+------------------------------------------------------------------------------
+                                                           *'NERDTreeDirArrows'*
+Values: 0 or 1
+Default: 0.
+
+This option is used to change the default look of directory nodes displayed in
+the tree. When set to 0 it shows old-school bars (|), + and ~ chars. If set to
+1 it shows right and down arrows.  Use one of the follow lines to set this
+option: >
+    let NERDTreeDirArrows=0
+    let NERDTreeDirArrows=1
+<
 
 ==============================================================================
 4. The NERD tree API                                             *NERDTreeAPI*


### PR DESCRIPTION
I've made small modification that adds an option to change the look of NERDTree.

It is NERDTreeDirArrows (default 0), when it's set to 1 NERDTree displays right and down arrow (triangle) chars for directory nodes instead of + and ~. It also hides | and `. 

There are many forks that have similar modification but they totally wipe the old look/behavior. I think it's good to have an option to turn it on as some users might want to stay with the old-school look.
