### PR TITLE
NERDTreeFind fix

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -991,7 +991,7 @@ function! s:TreeFileNode.getLineNum()
     "the path components we have matched so far
     let pathcomponents = [substitute(b:NERDTreeRoot.path.str({'format': 'UI'}), '/ *$', '', '')]
     "the index of the component we are searching for
-    let curPathComponent = 1
+    let curPathComponent = 0
 
     let fullpath = self.path.str({'format': 'UI'})
 


### PR DESCRIPTION
Recently, I had problem with NERDTreeFind command: it correctly unfolded dirs to show the file I am on, but didn't jump the cursor to it.

Change in this pull reguest fixed this problem for me.
