### PR TITLE
NERDTreeFind fix revert

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -991,7 +991,7 @@ function! s:TreeFileNode.getLineNum()
     "the path components we have matched so far
     let pathcomponents = [substitute(b:NERDTreeRoot.path.str({'format': 'UI'}), '/ *$', '', '')]
     "the index of the component we are searching for
-    let curPathComponent = 0
+    let curPathComponent = 1
 
     let fullpath = self.path.str({'format': 'UI'})
 


### PR DESCRIPTION
Some other changes caused previous commit to break the NERDTreeFind functionality [see issue](https://github.com/scrooloose/nerdtree/pull/56)
instead of fixing it. Reverting...

New version works fine with the original value of curPathComponent.
