### PR TITLE
Add windows network share support

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2110,6 +2110,7 @@ endfunction
 function! s:Path.extractDriveLetter(fullpath)
     if s:running_windows
         if a:fullpath =~ '^\(\\\\\|\/\/\)'
+            "For network shares, the 'drive' consists of the first two parts of the path, i.e. \\boxname\share
             let self.drive = substitute(a:fullpath, '^\(\(\\\\\|\/\/\)[^\\\/]*\(\\\|\/\)[^\\\/]*\).*', '\1', '')
             let self.drive = substitute(self.drive, '/', '\', "g")
         else


### PR DESCRIPTION
Hi,

I've made a small branch to add support for browsing windows network shares directly (I raised this missing support as issue 77: https://github.com/scrooloose/nerdtree/issues/77) - previously the plugin assumed all windows paths required a drive letter. The network share root path is now used as the 'drive letter'.

Thanks!
Dave
