### PR TITLE
Fix for an error when copying nodes

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -866,8 +866,10 @@ function! s:TreeFileNode.copy(dest)
     let parent = b:NERDTreeRoot.findNode(newPath.getParent())
     if !empty(parent)
         call parent.refresh()
+        return parent.findNode(newPath)
+    else
+        return {}
     endif
-    return parent.findNode(newPath)
 endfunction
 
 "FUNCTION: TreeFileNode.delete {{{3


### PR DESCRIPTION
I've been seeing an error when copying nodes to directories outside of the current one. It looks like this:

```
NERDTree: Copying...
Error detected while processing function <SNR>122_ExecuteCopy..62:
line    7:
E716: Key not present in Dictionary: findNode(newPath)
E15: Invalid expression: parent.findNode(newPath)
```

This pull request fixes the problem on my linux machine. I think it should also fix [issue#25](https://github.com/scrooloose/nerdtree/issues/25).
