### PR TITLE
Prevent nerdtree from splitting other window, when that is just empty (&buftype=='nofile')

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -3068,7 +3068,7 @@ function! s:firstUsableWindow()
     let i = 1
     while i <= winnr("$")
         let bnum = winbufnr(i)
-        if bnum != -1 && getbufvar(bnum, '&buftype') ==# ''
+        if bnum != -1 && (getbufvar(bnum, '&buftype') == '' || getbufvar(bnum, '&buftype') == 'nofile')
                     \ && !getwinvar(i, '&previewwindow')
                     \ && (!getbufvar(bnum, '&modified') || &hidden)
             return i
@@ -3184,7 +3184,7 @@ function! s:isWindowUsable(winnumber)
 
     let oldwinnr = winnr()
     call s:exec(a:winnumber . "wincmd p")
-    let specialWindow = getbufvar("%", '&buftype') != '' || getwinvar('%', '&previewwindow')
+    let specialWindow = !(getbufvar("%", '&buftype') == '' || getbufvar("%", '&buftype') == 'nofile') || getwinvar('%', '&previewwindow')
     let modified = &modified
     call s:exec(oldwinnr . "wincmd p")
 


### PR DESCRIPTION
I often have the situation where I close all existing buffers (except the NERDTree buffer), and then start opening files from NERDTree again.

When doing this, NERDTree opens the files in a new split window, i.e. I have NERDTree at the left side, and on the right side two windows on top of each other, an emtpy buffer and the file I wanted to open.

What I want to happen is that NERDTree opens the file in the right window without splitting it.
This commit fixes this problem, although I'm not sure whether this is the best way to accomplish
this..
