### PR TITLE
stayInCurrentTab fix

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -399,7 +399,7 @@ function! s:Bookmark.openInNewTab(options)
         exec "tabedit " . self.path.str({'format': 'Edit'})
     endif
 
-    if has_key(a:options, 'stayInCurrentTab')
+    if has_key(a:options, 'stayInCurrentTab') && a:options['stayInCurrentTab']
         exec "tabnext " . currentTab
     endif
 endfunction


### PR DESCRIPTION
The dictionary that Bookmark.openInNewTab takes as a parameter can have the key 'stayInCurrentTab', which has the same meaning as in TreeDirNode.openInNewTab and TreeFileNode.openInNewTab.  Bookmark.openInNewTab is not checking the value of the key, only its existence, so a call like:

NERDTreeBookmark.GetSelected().openInNewTab({'stayInCurrentTab': 0})

Will actually keep you in the current tab even though the value passed was 0.  This change makes the check in Bookmark.openInNewTab consistent with those in TreeDirNode.openInNewTab and TreeFileNode.openInNewTab.
