### PR TITLE
Symlinks Not Showing as Symlinks

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2521,6 +2521,16 @@ function! s:Path.Slash()
     return s:running_windows ? '\' : '/'
 endfunction
 
+"FUNCTION: Path.Resolve() {{{3
+"Invoke the vim resolve() function and return the result
+"This is necessary because in some versions of vim resolve() removes trailing
+"slashes while in other versions it doesn't.  This always removes the trailing
+"slash
+function! s:Path.Resolve(path)
+    let tmp = resolve(a:path)
+    return tmp =~# '/$' ? substitute(tmp, '/$', '', '') : tmp
+endfunction
+
 "FUNCTION: Path.readInfoFromDisk(fullpath) {{{3
 "
 "
@@ -2555,12 +2565,12 @@ function! s:Path.readInfoFromDisk(fullpath)
     let lastPathComponent = self.getLastPathComponent(0)
 
     "get the path to the new node with the parent dir fully resolved
-    let hardPath = resolve(self.strTrunk()) . '/' . lastPathComponent
+    let hardPath = s:Path.Resolve(self.strTrunk()) . '/' . lastPathComponent
 
     "if  the last part of the path is a symlink then flag it as such
-    let self.isSymLink = (resolve(hardPath) != hardPath)
+    let self.isSymLink = (s:Path.Resolve(hardPath) != hardPath)
     if self.isSymLink
-        let self.symLinkDest = resolve(fullpath)
+        let self.symLinkDest = s:Path.Resolve(fullpath)
 
         "if the link is a dir then slap a / on the end of its dest
         if isdirectory(self.symLinkDest)
@@ -2971,7 +2981,7 @@ function! s:initNerdTree(name)
         if dir =~# '^\.'
             let dir = getcwd() . s:Path.Slash() . dir
         endif
-        let dir = resolve(dir)
+        let dir = s:Path.Resolve(dir)
 
         try
             let path = s:Path.New(dir)


### PR DESCRIPTION
Commit bc745b6e99888c97c7e8f6ff3b7e8f605cab5af1 introduced code which changed how "hardPath" is calculated.  Essentially it moved the addition of a "/" between the last path component and the rest of the path from s:Path.readInfoFromDisk() down into s:Path.strTrunk().  However, on my system this breaks the calculation of hardPath, as resolve() removes the trailing "/" returned by s:Path.strTrunk():

On my system, these two commands return different results:

:echo g:NERDTreeFileNode.GetSelected().path.strTrunk() 
-> "/Users/cperl/tmp/2012-01-09/t/" (with trailing "/")

:echo resolve(g:NERDTreeFileNode.GetSelected().path.strTrunk())
-> "/Users/cperl/tmp/2012-01-09/t" (without trailing "/")

This means that for an example directory structure like this:

[cperl@screed ~/tmp/2012-01-09]$ tree -f -i t/
t
t/a
t/b -> a

2 directories, 0 files

hardPath for t/a becomes "/Users/cperl/tmp/2012-01-09/ta" and for t/b becomes "/Users/cperl/tmp/2012-01-09/tb".  Since these are bogus paths, resolve(hardPath) will always be equal to hardPath and hence nothing will be flagged as a symlink.

Just as an example having nothing to do with NERDTree showing resolve removing the trailing slash:

:echo resolve("/foo/bar/baz/")
-> "/foo/bar/baz"
