### PR TITLE
Add calls to NERDTreeAddKeyMap for previewing Bookmarks

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2881,6 +2881,10 @@ function! s:createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewVSplit, 'scope': "Node", 'callback': s."previewNodeVSplit" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewSplit, 'scope': "Node", 'callback': s."previewNodeHSplit" })
 
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': "Bookmark", 'callback': s."previewNodeCurrent" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewVSplit, 'scope': "Bookmark", 'callback': s."previewNodeVSplit" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewSplit, 'scope': "Bookmark", 'callback': s."previewNodeHSplit" })
+
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenRecursively, 'scope': "DirNode", 'callback': s."openNodeRecursively" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUpdir, 'scope': "all", 'callback': s."upDirCurrentRootClosed" })


### PR DESCRIPTION
These calls to NERDTreeAddKeyMap use the same callback as when these
keys are mapped with a 'scope' of "Node."  This should not pose a
problem though as s:previewNodeCurrent, s:previewNodeHSplit and
s:previewNodeVSplit all just call the passed in node's open() method,
which gets passed on to an Opener object.
