### PR TITLE
Double edit fix

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -1229,7 +1229,6 @@ endfunction
 
 "FUNCTION: TreeFileNode.open() {{{3
 function! s:TreeFileNode.open(...)
-    echomsg self.path.str()
     let opts = a:0 ? a:1 : {}
     let opener = s:Opener.New(self.path, opts)
     call opener.open(self)


### PR DESCRIPTION
Since a recent update of the plugin, opening up a file with the standard `o` mapping seems to edit it twice. The output in the command line looks a bit like this:

```
/home/andrew/notes
"notes" 127L, 3266C
"notes" 127L, 3266C
```

This causes an annoying hit-enter prompt. The problem is probably limited to my configuration, since I have a `set shortmess=aTI` in my config. Putting an `O` in there fixes my immediate issue, but there's still a double-edit in there.

After poking around in the code, I found out that the function `Opener._gotoTargetWin()`, which is called right before `Path.edit`, calls `Opener._previousWindow()`, which also edits the file. Removing the editing in `_previousWindow()` seems safe enough to me, since I couldn't find a code path that leads to `_previousWindow()` being called without an edit later.

Another thing I removed is an `echomsg` of the file name, since it adds one more line to the output that's overridden by the standard file edit message anyway.
