### PR TITLE
Replace virtcol() with len() in handleLeftClick().

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -4106,7 +4106,7 @@ function! s:handleLeftClick()
         "take the line substring manually
         let line = split(getline(line(".")), '\zs')
         let startToCur = ""
-        for i in range(0,virtcol(".")-1)
+        for i in range(0,len(line)-1)
             let startToCur .= line[i]
         endfor
 


### PR DESCRIPTION
When 'virtualedit' is set, the column where the cursor resides can no longer be
relied on for determining the number of elements in the 'line' list for
iterating.  Replacing virtcol() with len() seems to work correctly and not
result in E684 errors.  Fixes Issue #144
