### PR TITLE
Catch errors in handleLeftClick()

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -4107,7 +4107,7 @@ function! s:handleLeftClick()
         let line = split(getline(line(".")), '\zs')
         let startToCur = ""
         for i in range(0,virtcol(".")-1)
-            let startToCur .= line[i]
+            try | let startToCur .= line[i] | catch | endtry
         endfor
 
         if currentNode.path.isDirectory


### PR DESCRIPTION
This commit fixes issue #144. This [pull request](https://github.com/scrooloose/nerdtree/pull/150) does not work properly for me, i.e, substituting `virtcol()` with `len()`. Simply wrapping that line in `try`/`catch` does.
