### PR TITLE
Files matching wildignore patterns are not shown in NERDTree

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -1617,7 +1617,7 @@ function! s:TreeDirNode._initChildren(silent)
     "get an array of all the files in the nodes dir
     let dir = self.path
     let globDir = dir.str({'format': 'Glob'})
-    let filesStr = globpath(globDir, '*') . "\n" . globpath(globDir, '.*')
+    let filesStr = globpath(globDir, '*',1) . "\n" . globpath(globDir, '.*',1)
     let files = split(filesStr, "\n")
 
     if !a:silent && len(files) > g:NERDTreeNotificationThreshold


### PR DESCRIPTION
I have .git, .hg, .png etc in wildignore - based upon the vimified .vimrc. The Janus distribution also uses wildignore to hide certain kinds of files.

Unfortunately, any files matching a pattern in wildignore are invisible in NERDTree - and it's really not obvious why.

This patch causes globpath to ignore wildignore settings when building the NERDTreeDirNode children list.
