### PR TITLE
Fix typo in copy action

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -26,7 +26,7 @@ if has("gui_mac") || has("gui_macvim")
 endif
 
 if g:NERDTreePath.CopyingSupported()
-    call NERDTreeAddMenuItem({'text': '(c)copy the current node', 'shortcut': 'c', 'callback': 'NERDTreeCopyNode'})
+    call NERDTreeAddMenuItem({'text': '(c)opy the current node', 'shortcut': 'c', 'callback': 'NERDTreeCopyNode'})
 endif
 
 "FUNCTION: s:echo(msg){{{1


### PR DESCRIPTION
Other options were printed as `(m)ove` or `(d)elete`, but copy was `(c)copy`.  Now it's `(c)opy`.
