### PR TITLE
NERD tree doesn't currently work on Vim 7.2 and below.

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -1618,7 +1618,13 @@ function! s:TreeDirNode._initChildren(silent)
     "get an array of all the files in the nodes dir
     let dir = self.path
     let globDir = dir.str({'format': 'Glob'})
-    let filesStr = globpath(globDir, '*',1) . "\n" . globpath(globDir, '.*',1)
+
+    if version >= 703
+        let filesStr = globpath(globDir, '*', 1) . "\n" . globpath(globDir, '.*', 1)
+    else
+        let filesStr = globpath(globDir, '*') . "\n" . globpath(globDir, '.*')
+    endif
+
     let files = split(filesStr, "\n")
 
     if !a:silent && len(files) > g:NERDTreeNotificationThreshold


### PR DESCRIPTION
globpath() takes an extra optional parameter in Vim 7.3, but this
breaks NERD tree on earlier versions.
