### PR TITLE
Make NERDTreeFind work on hidden files

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2999,6 +2999,11 @@ function! s:findAndRevealPath()
         return
     endtry
 
+    if p.getLastPathComponent(0) =~# '^\.'
+        let showhidden=g:NERDTreeShowHidden
+        let g:NERDTreeShowHidden = 1
+    endif
+
     if !s:treeExistsForTab()
         try
             let cwd = s:Path.New(getcwd())
@@ -3023,6 +3028,10 @@ function! s:findAndRevealPath()
     endif
     call s:putCursorInTreeWin()
     call b:NERDTreeRoot.reveal(p)
+
+    if p.getLastPathComponent(0) =~# '^\.'
+        let g:NERDTreeShowHidden = showhidden
+    endif
 endfunction
 
 " FUNCTION: s:has_opt(options, name) {{{2


### PR DESCRIPTION
Fix #189.

While executing `NERDTreeFind` on a hidden file, it implicates that hidden files should be shown in current NERDTree Window, this PL will do just that.
