### PR TITLE
Reveal the current editing file in current NERDTree window instaead initiating a new one

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -3019,7 +3019,13 @@ function! s:findAndRevealPath()
         endif
     else
         if !p.isUnder(s:TreeFileNode.GetRootForTab().path)
-            call s:initNerdTree(p.getParent().str())
+            if !s:isTreeOpen()
+                call s:createTreeWin()
+            else
+                call s:putCursorInTreeWin()
+            endif
+            let b:NERDTreeShowHidden = g:NERDTreeShowHidden
+            call s:chRoot(s:TreeDirNode.New(p.getParent()))
         else
             if !s:isTreeOpen()
                 call s:toggle("")


### PR DESCRIPTION
This PL relys on #202, please merge it first, I am trying to make a separate PL history.

When a tab already has a NERDTree window open, make `NERDTreeFind` use the existing NERDTree window instead of closing it and creating a new one. This would avoid unexpected results while a tab is using a mirrored NERDTree.
