### PR TITLE
Fix s:Path.Resolve to it handles '/' properly

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2600,7 +2600,7 @@ endfunction
 "slash
 function! s:Path.Resolve(path)
     let tmp = resolve(a:path)
-    return tmp =~# '/$' ? substitute(tmp, '/$', '', '') : tmp
+    return tmp =~# '.\+/$' ? substitute(tmp, '/$', '', '') : tmp
 endfunction
 
 "FUNCTION: Path.readInfoFromDisk(fullpath) {{{3


### PR DESCRIPTION
I added this function in commit ba74b99fd716b62e4073a1c23d62e0a3a4bc34de, so its my own fault, but it doesn't handle the root dir properly.
