### PR TITLE
Set filetype unconditionally and after defining mappings.

### DIFF
--- a/plugin/nerdtree/creator.vim
+++ b/plugin/nerdtree/creator.vim
@@ -279,8 +279,8 @@ function! s:Creator._setCommonBufOptions()
     let b:NERDTreeShowFiles = g:NERDTreeShowFiles
     let b:NERDTreeShowHidden = g:NERDTreeShowHidden
     let b:NERDTreeShowBookmarks = g:NERDTreeShowBookmarks
-    setfiletype nerdtree
     call self._bindMappings()
+    setlocal filetype=nerdtree
 endfunction
 
 "FUNCTION: s:Creator._setupStatusline() {{{1


### PR DESCRIPTION
Because NERD_Tree sets the filetype in its buffer, it's tempting to hook into the FileType event in order to customize it. Unfortunately, the buffer-local mappings are only defined _after_ setting the filetype, so one cannot un-/redefine them via this mechanism. (I know there are config variables and an API for that, but one may have other unforeseen uses.)
Therefore, swap the order and set the filetype last. Also, use :setlocal filetype= instead of :setfiletype. In the (remote) chance that a custom filetype detection mistakenly sets a filetype for the NERD_Tree buffer, the :setfiletype would be without effect, but we want to force the filetype (for the special syntax) here.
