### PR TITLE
Minor fix to the FAQ

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,7 +80,7 @@ A. Stick this in your vimrc: `autocmd vimenter * NERDTree`
 
 __Q. How can I open a NERDTree automatically when vim starts up if no files were specified?__
 
-A. Stick this in your vimrc `autocmd vimenter * if !argc() | NERDTree | endif`
+A. Stick this in your vimrc `autocmd vimenter * if !argc() && !&modified | NERDTree | endif`
 
 __Q. How can I map a specific key or shortcut to open NERDTree?__
 


### PR DESCRIPTION
This is awkward to describe, sorry. :)

The old setting doesn't work when Vim reads a file from stdin, f.i.:

```
diff file1 file2 | vim -
```

In this situation `argc() == 0`, since no file has been named on the
command line, yet we don't want to open NERDTree, as we already
have a file to play with.  However, when Vim reads a file from stdin
the buffer is still marked as modified.  Hence the patch.
