### PR TITLE
Fix documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ Installation
     cd ~/.vim/bundle
     git clone https://github.com/scrooloose/nerdtree.git
 
-Then reload vim, run `:helptags`, and check out `:help NERD_tree.txt`.
+Then reload vim, run `:Helptags`, and check out `:help NERD_tree.txt`.
 
 
 Faq


### PR DESCRIPTION
According to the `pathogen` documentation:

> Provided with pathogen.vim is a `:Helptags` command that does this on
> every directory in your `'runtimepath'`.

The documentation here should reference the pathogen-specific
`:Helptags` command, not the general `:helptags`.
