### PR TITLE
don't redefine user-defined mappings

### DIFF
--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -44,7 +44,7 @@ function! s:KeyMap.bind()
 
     let premap = self.key == "<LeftRelease>" ? " <LeftRelease>" : " "
 
-    exec 'nnoremap <buffer> <silent> '. self.key . premap . ':call nerdtree#invokeKeyMap("'. keymapInvokeString .'")<cr>'
+    exec 'silent! nnoremap <buffer> <silent> <unique> '. self.key . premap . ':call nerdtree#invokeKeyMap("'. keymapInvokeString .'")<cr>'
 endfunction
 
 "FUNCTION: KeyMap.Remove(key, scope) {{{1


### PR DESCRIPTION
As a user it's a little jarring when a plugin maps over something I've
already defined.  This patch fixes that problem, by using `<unique>` to
ensure unique mappings.

For more info see `:help <unique>`

Note: This has no effect if the mapping isn't already defined (that is,
NERDTree is defining a unique mapping), so this won't break for normal
users of the plugin.

Note: `:silent!` is needed to ignore the error that occurs when a
mapping is already defined.

Fixes #252
