### PR TITLE
Allow selective mappings

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -1017,7 +1017,7 @@ option: >
 <
 
 ------------------------------------------------------------------------------
-                                          *'NERDTreeNoOverride'*
+                                                        *'NERDTreeNoOverride'*
 Values: An array of strings.
 Default: Nothing, ignored by default.
 
@@ -1025,8 +1025,10 @@ When entering a NERDTree window, certain keys are remapped for convenience. If
 you want some (or all) of them not to be remapped, you can specify that with
 this option.  For instance, to disallow mapping of Control+k and Control+j in
 NERDTree windows, you would set the following option: >
-    let NERDTreeNoOverride=['<C-k>', '<C-j>']
+    let NERDTreeNoOverride=['<c-k>', '<c-j>']
 <
+Note: mappings are specified as lowercase strings. The full list can be found
+under |NERDTreeMappings|.
 
 ==============================================================================
 4. The NERD tree API                                             *NERDTreeAPI*

--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -45,7 +45,7 @@ function! s:KeyMap.bind()
     let premap = self.key == "<LeftRelease>" ? " <LeftRelease>" : " "
 
     " don't remap keys the user specifies in g:NERDTreeNoOverride
-    if !exists('g:NERDTreeNoOverride') || !count(g:NERDTreeNoOverride, keymapInvokeString)
+    if !exists('g:NERDTreeNoOverride') || !count(g:NERDTreeNoOverride, tolower(self.key))
         exec 'nnoremap <buffer> <silent> '. self.key . premap . ':call nerdtree#invokeKeyMap("'. keymapInvokeString .'")<cr>'
     endif
 endfunction


### PR DESCRIPTION
Reverts #255 and adds a `g:NERDTreeNoOverride` option to allow some mappings to be ignored by NERDTree while others are still mapped.  Without this option the plugin should function as it did before 448ad6f1bce0308329ccb020b51710227108b578.
