### PR TITLE
Use :Helptags not :helptags

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ Installation
     cd ~/.vim/bundle
     git clone https://github.com/scrooloose/nerdtree.git
 
-Then reload vim, run `:helptags`, and check out `:help NERD_tree.txt`.
+Then reload vim, run `:Helptags`, and check out `:help NERD_tree.txt`.
 
 
 Faq


### PR DESCRIPTION
I'm not an expert on pathogen at all, but I believe that one should call `:Helptags` to rebuild the doc of all modules; `:helptags` requires a path.
