### PR TITLE
Added 'NERDTreeReuseWindows' option to choose whether to reuse windows while opening files

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -976,7 +976,7 @@ endfunction
 "FUNCTION: s:activateFileNode() {{{2
 "handle the user activating a tree node
 function! s:activateFileNode(node)
-    call a:node.activate({'reuse': 1, 'where': 'p'})
+    call a:node.activate({'reuse': g:NERDTreeReuseWindows, 'where': 'p'})
 endfunction
 
 "FUNCTION: s:activateBookmark() {{{2

--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -675,6 +675,10 @@ NERD tree. These options should be set in your vimrc.
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
+|'NERDTreeReuseWindows'|        If file is already being edited
+                                in some window: jump back to that window
+                                instead of opening the new one.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -1012,6 +1016,16 @@ option: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
 <
+
+------------------------------------------------------------------------------
+                                                      *'NERDTreeReuseWindows'*
+Values: 0 or 1
+Default: 1.
+
+While working with several windows and/or tabs there may be situation when
+you ask NERDTree to open file already being edited in other window.
+Default behavior is to jump to that window. If this option is not set
+NERDTree will always open selected file in previous window.
 
 ==============================================================================
 4. The NERD tree API                                             *NERDTreeAPI*

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -67,6 +67,7 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 call s:initVariable("g:NERDTreeDirArrows", !nerdtree#runningWindows())
 call s:initVariable("g:NERDTreeCasadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeReuseWindows", 1)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']


### PR DESCRIPTION
New option name: NERDTreeReuseWindows
Values: 0 or 1
Default: 1

While working with several windows and/or tabs there may be situation when
you ask NERDTree to open file already being edited in other window.
Default behavior is to jump to that window. If this option is not set
NERDTree will always open selected file in previous window.
