### PR TITLE
Create parent directories as needed when creating or copying nested nodes

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -141,6 +141,7 @@ function! s:Path.Create(fullpath)
 
         "assume its a file and create
         else
+            call s:Path.createParentDirectories(a:fullpath)
             call writefile([], a:fullpath)
         endif
     catch
@@ -160,6 +161,8 @@ function! s:Path.copy(dest)
     if !s:Path.CopyingSupported()
         throw "NERDTree.CopyingNotSupportedError: Copying is not supported on this OS"
     endif
+
+    call s:Path.createParentDirectories(a:dest)
 
     let dest = s:Path.WinToUnixPath(a:dest)
 
@@ -194,6 +197,20 @@ function! s:Path.copyingWillOverwrite(dest)
         if filereadable(path)
             return 1
         endif
+    endif
+endfunction
+
+"FUNCTION: Path.createParentDirectories(path) {{{1
+"
+"create parent directories for this path if needed
+"without throwing any errors is those directories already exist
+"
+"Args:
+"path: full path of the node whose parent directories may need to be created
+function! s:Path.createParentDirectories(path)
+    let dir_path = fnamemodify(a:path, ':h')
+    if !isdirectory(dir_path)
+        call mkdir(dir_path, 'p')
     endif
 endfunction
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -114,7 +114,10 @@ function! NERDTreeAddNode()
         let parentNode = b:NERDTreeRoot.findNode(newPath.getParent())
 
         let newTreeNode = g:NERDTreeFileNode.New(newPath)
-        if parentNode.isOpen || !empty(parentNode.children)
+        if empty(parentNode)
+            call b:NERDTreeRoot.refresh()
+            call nerdtree#renderView()
+        elseif parentNode.isOpen || !empty(parentNode.children)
             call parentNode.addChild(newTreeNode, 1)
             call NERDTreeRender()
             call newTreeNode.putCursorHere(1, 0)
@@ -224,7 +227,10 @@ function! NERDTreeCopyNode()
         if confirmed
             try
                 let newNode = currentNode.copy(newNodePath)
-                if !empty(newNode)
+                if empty(newNode)
+                    call b:NERDTreeRoot.refresh()
+                    call nerdtree#renderView()
+                else
                     call NERDTreeRender()
                     call newNode.putCursorHere(0, 0)
                 endif


### PR DESCRIPTION
Recursively creates parent directories as needed when a nested node is created or copied.

Fixes #163 and #34.
