### PR TITLE
Fix error 121 when clicking on command line below another window

### DIFF
--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -79,6 +79,9 @@ endfunction
 "If a keymap has the scope of "all" then it will be called if no other keymap
 "is found for a:key and the scope.
 function! s:KeyMap.Invoke(key)
+    if !exists('b:NERDTreeRoot')
+        return {}
+    endif
     let node = g:NERDTreeFileNode.GetSelected()
     if !empty(node)
 


### PR DESCRIPTION
I get this when having NERDTree active and clicking on the command line below another window:
Error detected while processing function nerdtree#invokeKeyMap..69..111..nerdtree#getPath:
line   41:
E121: Undefined variable: b:NERDTreeRoot
E15: Invalid expression: b:NERDTreeRoot.path.str({'format': 'UI'}) . dir

I've only tried it in Cygwin on Windows 7.

There's surely a better solution for this but it works for me, for now.
