### PR TITLE
Add option to respect wildignore

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -631,6 +631,8 @@ NERD tree. These options should be set in your vimrc.
 
 |'NERDTreeIgnore'|              Tells the NERD tree which files to ignore.
 
+|'NERDTreeWildIgnore'|          Tells the NERD tree to respect |'wildignore'|.
+
 |'NERDTreeBookmarksFile'|       Where the bookmarks are stored.
 
 |'NERDTreeMouseMode'|           Tells the NERD tree how to handle mouse
@@ -816,6 +818,13 @@ line: >
 
 The file filters can be turned on and off dynamically with the |NERDTree-f|
 mapping.
+
+------------------------------------------------------------------------------
+                                                        *'NERDTreeWildIgnore'*
+Values: 0 or 1.
+Default: 0.
+
+If set to 1, the |'wildignore'| setting is respected.
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeBookmarksFile'*

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -228,7 +228,7 @@ function! s:TreeDirNode._initChildren(silent)
     let dir = self.path
     let globDir = dir.str({'format': 'Glob'})
 
-    if version >= 703
+    if version >= 703 && g:NERDTreeWildIgnore
         let filesStr = globpath(globDir, '*', 1) . "\n" . globpath(globDir, '.*', 1)
     else
         let filesStr = globpath(globDir, '*') . "\n" . globpath(globDir, '.*')


### PR DESCRIPTION
I left it off by default to maintain the current behavior, but personally think it should be on by default instead. For reference, not respecting `wildignore` has added in #172.
