### PR TITLE
correct invalid reference to MenuController

### DIFF
--- a/lib/nerdtree/menu_item.vim
+++ b/lib/nerdtree/menu_item.vim
@@ -90,7 +90,7 @@ endfunction
 "callback
 function! s:MenuItem.execute()
     if len(self.children)
-        let mc = s:MenuController.New(self.children)
+        let mc = g:NERDTreeMenuController.New(self.children)
         call mc.showMenu()
     else
         if self.callback != -1


### PR DESCRIPTION
I found an error when I tried to use [git_menu.vim](https://gist.github.com/scrooloose/205785):

```
Error detected while processing function nerdtree#invokeKeyMap..91..90..<SNR>52_showMenu..65..82:
line    2:
E121: Undefined variable: s:MenuController
E15: Invalid expression: s:MenuController.New(self.children)
line    3:
E121: Undefined variable: mc
```

I searched the line at which it happened
then, I found that `s:MenuController` is not defined in  `menu_item.vim` but in menu_controller.vim .
So I corrected the name to refer to MenuController.
