### PR TITLE
Horizontal split - relative to the previous window

### DIFF
--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -92,7 +92,7 @@ function! s:Opener._newSplit()
     " splitbelow and splitright IF the explorer is the only window.
     "
     let there= g:NERDTreeWinPos ==# "left" ? "wincmd h" : "wincmd l"
-    let back = g:NERDTreeWinPos ==# "left" ? "wincmd l" : "wincmd h"
+    let back = "wincmd p"
     let right= g:NERDTreeWinPos ==# "left"
     let below=0
 


### PR DESCRIPTION
This patch causes splitting recently visited window with `i` key instead of the window adhering to the left or right - it gives you more control of where to place a new window.
