### PR TITLE
Support spaces and umlauts in path

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -82,13 +82,14 @@ endfunction
 function! s:promptToRenameBuffer(bufnum, msg, newFileName)
     echo a:msg
     if g:NERDTreeAutoDeleteBuffer || nr2char(getchar()) ==# 'y'
+        let quotedFileName = "'" . a:newFileName . "'"
         " 1. ensure that a new buffer is loaded
-        exec "badd " . a:newFileName
+        exec "badd " . quotedFileName
         " 2. ensure that all windows which display the just deleted filename
         " display a buffer for a new filename. 
         let s:originalTabNumber = tabpagenr()
         let s:originalWindowNumber = winnr()
-        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':e! " . a:newFileName . "' | endif"
+        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec \":e! " . quotedFileName . "\" | endif"
         exec "tabnext " . s:originalTabNumber
         exec s:originalWindowNumber . "wincmd w"
         " 3. We don't need a previous buffer anymore


### PR DESCRIPTION
When the path to the current working directory contains umlauts, I noticed that directory listings are incomplete. With a space in the path, renaming (`mm`) fails to remove the old buffer.

I'm using MacVim 7.4 on Mac OS X 10.9.3.
