### PR TITLE
Always show "up a dir" line

### DIFF
--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -211,10 +211,8 @@ function! s:UI.render()
     endif
 
     "add the 'up a dir' line
-    if !g:NERDTreeMinimalUI
-        call setline(line(".")+1, nerdtree#treeUpDirLine())
-        call cursor(line(".")+1, col("."))
-    endif
+    call setline(line(".")+1, nerdtree#treeUpDirLine())
+    call cursor(line(".")+1, col("."))
 
     "draw the header line
     let header = b:NERDTreeRoot.path.str({'format': 'UI', 'truncateTo': winwidth(0)})


### PR DESCRIPTION
As the doc said, the option 'NERDTreeMinimalUI' just disables display of the 'Bookmarks' label and 
'Press ? for help' text, so there might be no need to remove "up a dir" line.
