### PR TITLE
Use event BufLeave instead of BufWinLeave to record screen state

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -148,7 +148,7 @@ call nerdtree#ui_glue#setupCommands()
 "============================================================
 augroup NERDTree
     "Save the cursor position whenever we close the nerd tree
-    exec "autocmd BufWinLeave ". g:NERDTreeCreator.BufNamePrefix() ."* call b:NERDTree.ui.saveScreenState()"
+    exec "autocmd BufLeave ". g:NERDTreeCreator.BufNamePrefix() ."* call b:NERDTree.ui.saveScreenState()"
 
     "disallow insert mode in the NERDTree
     exec "autocmd BufEnter ". g:NERDTreeCreator.BufNamePrefix() ."* stopinsert"


### PR DESCRIPTION
Use event BufLeave instead of BufWinLeave to record screen state to avoid undefined b:NERDTree error . 
The BufWinLeave event also triggered when exiting(:qa), will cause an undefined b:NERDTree error.
