### PR TITLE
add refreshDirFlags method to avoid refreshing too many files

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -448,6 +448,11 @@ function! s:TreeDirNode.refreshFlags()
     endfor
 endfunction
 
+"FUNCTION: TreeDirNode.refreshDirFlags() {{{1
+function! s:TreeDirNode.refreshDirFlags()
+    call self.path.refreshFlags()
+endfunction
+
 "FUNCTION: TreeDirNode.reveal(path) {{{1
 "reveal the given path, i.e. cache and open all treenodes needed to display it
 "in the UI


### PR DESCRIPTION
I added a new function called `refreshDirFlags` for dir node used in this case:

```
autocmd BufWritePost * call s:FileUpdate(expand("%"))
" FUNCTION: s:FileUpdate(fname) {{{2
function! s:FileUpdate(fname)
    if !nerdtree#isTreeOpen()
        return
    endif

    call nerdtree#putCursorInTreeWin()
    let node = b:NERDTreeRoot.findNode(g:NERDTreePath.New(a:fname))
    call node.refreshFlags()
    let node = node.parent
    while !empty(node)
        call node.refreshDirFlags()
        let node = node.parent
    endwhile

    call NERDTreeRender()
endfunction
```

```
.
├── a
├── b
├── c
├── d
├── dir1
│   └── dir2
│       └── dir3
│           └── m
├── e
├── f
├── g
├── h
├── i
├── j
├── k
└── l
```

If you edit dir1/dir2/dir3/m, there is no need to refresh a, b, c... The Save event of file m only affect its parents directory.
