### PR TITLE
Update path.vim Path._strForEdit() return relative directory

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -677,7 +677,7 @@ function! s:Path._strForEdit()
         let p = '.'
     endif
 
-    return p
+    return fnamemodify(p, ':.')
 endfunction
 
 "FUNCTION: Path._strForGlob() {{{1


### PR DESCRIPTION
Update path.vim Path._strForEdit() to return a path relative to current directory.
