### PR TITLE
Lint vimscript, fix errors and warnings, add CI job to review PRs

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -1,0 +1,15 @@
+name: Vint
+on: [push, pull_request]
+jobs:
+  vint:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run vint with reviewdog
+      uses: reviewdog/action-vint@v1.0.1
+      with:
+        github_token: ${{ secrets.github_token }}
+        reporter: github-pr-review

--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+cmdargs:
+  severity: style_problem
+  color: true
+  env:
+    neovim: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.4
+- **.2**: Lint vimscript, fix errors and warnings, add CI job to review PRs (Caleb Maclennan) [#1071](https://github.com/preservim/nerdtree/pull/1071)
 - **.1**: Ensure backward compatibility. v:t_func is not available before Vim 8.0 (Phil Runninger)
 - **.0**: Allow use of function references as callbacks (HiPhish) [#1067](https://github.com/scrooloose/nerdtree/pull/1067)
 #### 6.3

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-The NERDTree
+The NERDTree [![Vint](https://github.com/preservim/nerdtree/workflows/Vint/badge.svg)](https://github.com/preservim/nerdtree/actions?workflow=Vint)
 =============
 
 Introduction

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -1,9 +1,9 @@
-if exists("g:loaded_nerdtree_autoload")
+if exists('g:loaded_nerdtree_autoload')
     finish
 endif
 let g:loaded_nerdtree_autoload = 1
 
-let s:rootNERDTreePath = resolve(expand("<sfile>:p:h:h"))
+let s:rootNERDTreePath = resolve(expand('<sfile>:p:h:h'))
 
 "FUNCTION: nerdtree#version(...) {{{1
 "  If any value is given as an argument, the entire line of text from the
@@ -12,7 +12,7 @@ let s:rootNERDTreePath = resolve(expand("<sfile>:p:h:h"))
 function! nerdtree#version(...)
     let l:text = 'Unknown'
     try
-        let l:changelog = readfile(join([s:rootNERDTreePath, "CHANGELOG.md"], nerdtree#slash()))
+        let l:changelog = readfile(join([s:rootNERDTreePath, 'CHANGELOG.md'], nerdtree#slash()))
         let l:line = 0
         while l:line <= len(l:changelog)
             if l:changelog[l:line] =~ '\d\+\.\d\+'
@@ -47,7 +47,7 @@ endfunction
 "FUNCTION: nerdtree#and(x,y) {{{2
 " Implements and() function for Vim <= 7.2
 function! nerdtree#and(x,y)
-    if exists("*and")
+    if exists('*and')
         return and(a:x, a:y)
     else
         let l:x = a:x
@@ -83,18 +83,18 @@ endfunction
 "FUNCTION: s:reuseWin(dir) {{{2
 "finds a NERDTree buffer with root of dir, and opens it.
 function! s:reuseWin(dir) abort
-    let path = g:NERDTreePath.New(fnamemodify(a:dir, ":p"))
+    let path = g:NERDTreePath.New(fnamemodify(a:dir, ':p'))
 
-    for i in range(1, bufnr("$"))
+    for i in range(1, bufnr('$'))
         unlet! nt
-        let nt = getbufvar(i, "NERDTree")
+        let nt = getbufvar(i, 'NERDTree')
         if empty(nt)
             continue
         endif
 
         if nt.isWinTree() && nt.root.path.equals(path)
-            call nt.setPreviousBuf(bufnr("#"))
-            exec "buffer " . i
+            call nt.setPreviousBuf(bufnr('#'))
+            exec 'buffer ' . i
             return 1
         endif
     endfor
@@ -207,12 +207,12 @@ endfunction
 
 "FUNCTION: nerdtree#runningWindows(dir) {{{2
 function! nerdtree#runningWindows()
-    return has("win16") || has("win32") || has("win64")
+    return has('win16') || has('win32') || has('win64')
 endfunction
 
 "FUNCTION: nerdtree#runningCygwin(dir) {{{2
 function! nerdtree#runningCygwin()
-    return has("win32unix")
+    return has('win32unix')
 endfunction
 
 " SECTION: View Functions {{{1
@@ -225,7 +225,7 @@ endfunction
 "msg: the message to echo
 function! nerdtree#echo(msg)
     redraw
-    echomsg empty(a:msg) ? "" : ("NERDTree: " . a:msg)
+    echomsg empty(a:msg) ? '' : ('NERDTree: ' . a:msg)
 endfunction
 
 "FUNCTION: nerdtree#echoError {{{2

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -165,12 +165,12 @@ endfunction
 " FUNCTION: nerdtree#exec(cmd, ignoreAll) {{{2
 " Same as :exec cmd but, if ignoreAll is TRUE, set eventignore=all for the duration
 function! nerdtree#exec(cmd, ignoreAll) abort
-    let old_ei = &ei
+    let old_ei = &eventignore
     if a:ignoreAll
-        set ei=all
+        set eventignore=all
     endif
     exec a:cmd
-    let &ei = old_ei
+    let &eventignore = old_ei
 endfunction
 
 " FUNCTION: nerdtree#has_opt(options, name) {{{2

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -15,7 +15,7 @@ function! nerdtree#version(...)
         let l:changelog = readfile(join([s:rootNERDTreePath, 'CHANGELOG.md'], nerdtree#slash()))
         let l:line = 0
         while l:line <= len(l:changelog)
-            if l:changelog[l:line] =~ '\d\+\.\d\+'
+            if l:changelog[l:line] =~# '\d\+\.\d\+'
                 let l:text = substitute(l:changelog[l:line], '.*\(\d\+.\d\+\).*', '\1', '')
                 let l:text .= substitute(l:changelog[l:line+1], '^.\{-}\(\.\d\+\).\{-}:\(.*\)', a:0>0 ? '\1:\2' : '\1', '')
                 break
@@ -122,15 +122,15 @@ function! nerdtree#compareNodesBySortKey(n1, n2)
         " Compare chunks upto common length.
         " If chunks have different type, the one which has
         " integer type is the lesser.
-        if type(sortKey1[i]) == type(sortKey2[i])
+        if type(sortKey1[i]) ==# type(sortKey2[i])
             if sortKey1[i] <# sortKey2[i]
                 return - 1
             elseif sortKey1[i] ># sortKey2[i]
                 return 1
             endif
-        elseif type(sortKey1[i]) == v:t_number
+        elseif type(sortKey1[i]) ==# v:t_number
             return -1
-        elseif type(sortKey2[i]) == v:t_number
+        elseif type(sortKey2[i]) ==# v:t_number
             return 1
         endif
         let i = i + 1
@@ -175,7 +175,7 @@ endfunction
 
 " FUNCTION: nerdtree#has_opt(options, name) {{{2
 function! nerdtree#has_opt(options, name)
-    return has_key(a:options, a:name) && a:options[a:name] == 1
+    return has_key(a:options, a:name) && a:options[a:name] ==# 1
 endfunction
 
 " FUNCTION: nerdtree#loadClassFiles() {{{2

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -9,7 +9,7 @@ let s:rootNERDTreePath = resolve(expand('<sfile>:p:h:h'))
 "  If any value is given as an argument, the entire line of text from the
 "  change log is shown for the current version; otherwise, only the version
 "  number is shown.
-function! nerdtree#version(...)
+function! nerdtree#version(...) abort
     let l:text = 'Unknown'
     try
         let l:changelog = readfile(join([s:rootNERDTreePath, 'CHANGELOG.md'], nerdtree#slash()))
@@ -31,7 +31,7 @@ endfunction
 "============================================================
 
 "FUNCTION: nerdtree#slash() {{{2
-function! nerdtree#slash()
+function! nerdtree#slash() abort
 
     if nerdtree#runningWindows()
         if exists('+shellslash') && &shellslash
@@ -46,7 +46,7 @@ endfunction
 
 "FUNCTION: nerdtree#and(x,y) {{{2
 " Implements and() function for Vim <= 7.2
-function! nerdtree#and(x,y)
+function! nerdtree#and(x,y) abort
     if exists('*and')
         return and(a:x, a:y)
     else
@@ -68,7 +68,7 @@ endfunction
 
 "FUNCTION: nerdtree#checkForBrowse(dir) {{{2
 "inits a window tree in the current buffer if appropriate
-function! nerdtree#checkForBrowse(dir)
+function! nerdtree#checkForBrowse(dir) abort
     if !isdirectory(a:dir)
         return
     endif
@@ -104,17 +104,17 @@ endfunction
 
 " FUNCTION: nerdtree#completeBookmarks(A,L,P) {{{2
 " completion function for the bookmark commands
-function! nerdtree#completeBookmarks(A,L,P)
+function! nerdtree#completeBookmarks(A,L,P) abort
     return filter(g:NERDTreeBookmark.BookmarkNames(), 'v:val =~# "^' . a:A . '"')
 endfunction
 
 "FUNCTION: nerdtree#compareNodes(dir) {{{2
-function! nerdtree#compareNodes(n1, n2)
+function! nerdtree#compareNodes(n1, n2) abort
     return a:n1.path.compareTo(a:n2.path)
 endfunction
 
 "FUNCTION: nerdtree#compareNodesBySortKey(n1, n2) {{{2
-function! nerdtree#compareNodesBySortKey(n1, n2)
+function! nerdtree#compareNodesBySortKey(n1, n2) abort
     let sortKey1 = a:n1.path.getSortKey()
     let sortKey2 = a:n2.path.getSortKey()
     let i = 0
@@ -150,7 +150,7 @@ endfunction
 " FUNCTION: nerdtree#deprecated(func, [msg]) {{{2
 " Issue a deprecation warning for a:func. If a second arg is given, use this
 " as the deprecation message
-function! nerdtree#deprecated(func, ...)
+function! nerdtree#deprecated(func, ...) abort
     let msg = a:0 ? a:func . ' ' . a:1 : a:func . ' is deprecated'
 
     if !exists('s:deprecationWarnings')
@@ -164,7 +164,7 @@ endfunction
 
 " FUNCTION: nerdtree#exec(cmd, ignoreAll) {{{2
 " Same as :exec cmd but, if ignoreAll is TRUE, set eventignore=all for the duration
-function! nerdtree#exec(cmd, ignoreAll)
+function! nerdtree#exec(cmd, ignoreAll) abort
     let old_ei = &ei
     if a:ignoreAll
         set ei=all
@@ -174,12 +174,12 @@ function! nerdtree#exec(cmd, ignoreAll)
 endfunction
 
 " FUNCTION: nerdtree#has_opt(options, name) {{{2
-function! nerdtree#has_opt(options, name)
+function! nerdtree#has_opt(options, name) abort
     return has_key(a:options, a:name) && a:options[a:name] ==# 1
 endfunction
 
 " FUNCTION: nerdtree#loadClassFiles() {{{2
-function! nerdtree#loadClassFiles()
+function! nerdtree#loadClassFiles() abort
     runtime lib/nerdtree/path.vim
     runtime lib/nerdtree/menu_controller.vim
     runtime lib/nerdtree/menu_item.vim
@@ -197,7 +197,7 @@ function! nerdtree#loadClassFiles()
 endfunction
 
 " FUNCTION: nerdtree#postSourceActions() {{{2
-function! nerdtree#postSourceActions()
+function! nerdtree#postSourceActions() abort
     call g:NERDTreeBookmark.CacheBookmarks(1)
     call nerdtree#ui_glue#createDefaultBindings()
 
@@ -206,12 +206,12 @@ function! nerdtree#postSourceActions()
 endfunction
 
 "FUNCTION: nerdtree#runningWindows(dir) {{{2
-function! nerdtree#runningWindows()
+function! nerdtree#runningWindows() abort
     return has('win16') || has('win32') || has('win64')
 endfunction
 
 "FUNCTION: nerdtree#runningCygwin(dir) {{{2
-function! nerdtree#runningCygwin()
+function! nerdtree#runningCygwin() abort
     return has('win32unix')
 endfunction
 
@@ -223,7 +223,7 @@ endfunction
 "
 "Args:
 "msg: the message to echo
-function! nerdtree#echo(msg)
+function! nerdtree#echo(msg) abort
     redraw
     echomsg empty(a:msg) ? '' : ('NERDTree: ' . a:msg)
 endfunction
@@ -232,7 +232,7 @@ endfunction
 "Wrapper for nerdtree#echo, sets the message type to errormsg for this message
 "Args:
 "msg: the message to echo
-function! nerdtree#echoError(msg)
+function! nerdtree#echoError(msg) abort
     echohl errormsg
     call nerdtree#echo(a:msg)
     echohl normal
@@ -242,14 +242,14 @@ endfunction
 "Wrapper for nerdtree#echo, sets the message type to warningmsg for this message
 "Args:
 "msg: the message to echo
-function! nerdtree#echoWarning(msg)
+function! nerdtree#echoWarning(msg) abort
     echohl warningmsg
     call nerdtree#echo(a:msg)
     echohl normal
 endfunction
 
 "FUNCTION: nerdtree#renderView {{{2
-function! nerdtree#renderView()
+function! nerdtree#renderView() abort
     call b:NERDTree.render()
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -4,7 +4,7 @@ endif
 let g:loaded_nerdtree_ui_glue_autoload = 1
 
 " FUNCTION: nerdtree#ui_glue#createDefaultBindings() {{{1
-function! nerdtree#ui_glue#createDefaultBindings()
+function! nerdtree#ui_glue#createDefaultBindings() abort
     let s = '<SNR>' . s:SID() . '_'
 
     call NERDTreeAddKeyMap({ 'key': '<MiddleMouse>', 'scope': 'all', 'callback': s . 'handleMiddleMouse' })
@@ -83,19 +83,19 @@ endfunction
 
 "FUNCTION: s:customOpenFile() {{{1
 " Open file node with the 'custom' key, initially <CR>.
-function! s:customOpenFile(node)
+function! s:customOpenFile(node) abort
     call a:node.activate(s:initCustomOpenArgs().file)
 endfunction
 
 "FUNCTION: s:customOpenDir() {{{1
 " Open directory node with the 'custom' key, initially <CR>.
-function! s:customOpenDir(node)
+function! s:customOpenDir(node) abort
     call s:activateDirNode(a:node, s:initCustomOpenArgs().dir)
 endfunction
 
 "FUNCTION: s:customOpenBookmark() {{{1
 " Open bookmark node with the 'custom' key, initially <CR>.
-function! s:customOpenBookmark(node)
+function! s:customOpenBookmark(node) abort
     if a:node.path.isDirectory
         call a:node.activate(b:NERDTree, s:initCustomOpenArgs().dir)
     else
@@ -105,14 +105,14 @@ endfunction
 
 "FUNCTION: s:initCustomOpenArgs() {{{1
 " Make sure NERDTreeCustomOpenArgs has needed keys
-function! s:initCustomOpenArgs()
+function! s:initCustomOpenArgs() abort
     let g:NERDTreeCustomOpenArgs = get(g:, 'NERDTreeCustomOpenArgs', {})
     return extend(g:NERDTreeCustomOpenArgs, {'file':{'reuse': 'all', 'where': 'p'}, 'dir':{}}, 'keep')
 endfunction
 
 "FUNCTION: s:activateAll() {{{1
 "handle the user activating the updir line
-function! s:activateAll()
+function! s:activateAll() abort
     if getline('.') ==# g:NERDTreeUI.UpDirLine()
         return nerdtree#ui_glue#upDir(0)
     endif
@@ -120,7 +120,7 @@ endfunction
 
 " FUNCTION: s:activateDirNode(directoryNode, options) {{{1
 " Open a directory with optional options
-function! s:activateDirNode(directoryNode, ...)
+function! s:activateDirNode(directoryNode, ...) abort
 
     if a:directoryNode.isRoot() && a:directoryNode.isOpen
         call nerdtree#echo('cannot close tree root')
@@ -132,19 +132,19 @@ endfunction
 
 "FUNCTION: s:activateFileNode() {{{1
 "handle the user activating a tree node
-function! s:activateFileNode(node)
+function! s:activateFileNode(node) abort
     call a:node.activate({'reuse': 'all', 'where': 'p'})
 endfunction
 
 "FUNCTION: s:activateBookmark(bookmark) {{{1
 "handle the user activating a bookmark
-function! s:activateBookmark(bm)
+function! s:activateBookmark(bm) abort
     call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p'} : {})
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#bookmarkNode(name) {{{1
 " Associate the current node with the given name
-function! nerdtree#ui_glue#bookmarkNode(...)
+function! nerdtree#ui_glue#bookmarkNode(...) abort
     let currentNode = g:NERDTreeFileNode.GetSelected()
     if currentNode !=# {}
         let name = a:1
@@ -163,7 +163,7 @@ function! nerdtree#ui_glue#bookmarkNode(...)
 endfunction
 
 " FUNCTION: s:chCwd(node) {{{1
-function! s:chCwd(node)
+function! s:chCwd(node) abort
     try
         call a:node.path.changeToDir()
     catch /^NERDTree.PathChangeError/
@@ -173,18 +173,18 @@ endfunction
 
 " FUNCTION: s:chRoot(node) {{{1
 " changes the current root to the selected one
-function! s:chRoot(node)
+function! s:chRoot(node) abort
     call b:NERDTree.changeRoot(a:node)
 endfunction
 
 " FUNCTION: s:nerdtree#ui_glue#chRootCwd() {{{1
 " Change the NERDTree root to match the current working directory.
-function! nerdtree#ui_glue#chRootCwd()
+function! nerdtree#ui_glue#chRootCwd() abort
     NERDTreeCWD
 endfunction
 
 " FUNCTION: nnerdtree#ui_glue#clearBookmarks(bookmarks) {{{1
-function! nerdtree#ui_glue#clearBookmarks(bookmarks)
+function! nerdtree#ui_glue#clearBookmarks(bookmarks) abort
     if a:bookmarks ==# ''
         let currentNode = g:NERDTreeFileNode.GetSelected()
         if currentNode !=# {}
@@ -202,7 +202,7 @@ endfunction
 
 " FUNCTION: s:closeChildren(node) {{{1
 " closes all childnodes of the current node
-function! s:closeChildren(node)
+function! s:closeChildren(node) abort
     call a:node.closeChildren()
     call b:NERDTree.render()
     call a:node.putCursorHere(0, 0)
@@ -210,7 +210,7 @@ endfunction
 
 " FUNCTION: s:closeCurrentDir(node) {{{1
 " Close the parent directory of the current node.
-function! s:closeCurrentDir(node)
+function! s:closeCurrentDir(node) abort
 
     if a:node.isRoot()
         call nerdtree#echo('cannot close parent of tree root')
@@ -235,7 +235,7 @@ endfunction
 
 " FUNCTION: s:closeTreeWindow() {{{1
 " close the tree window
-function! s:closeTreeWindow()
+function! s:closeTreeWindow() abort
     if b:NERDTree.isWinTree() && b:NERDTree.previousBuf() !=# -1
         exec 'buffer ' . b:NERDTree.previousBuf()
     else
@@ -249,7 +249,7 @@ endfunction
 
 " FUNCTION: s:deleteBookmark(bookmark) {{{1
 " Prompt the user to confirm the deletion of the selected bookmark.
-function! s:deleteBookmark(bookmark)
+function! s:deleteBookmark(bookmark) abort
     let l:message = 'Delete the bookmark "' . a:bookmark.name
                 \ . '" from the bookmark list?'
 
@@ -275,14 +275,14 @@ endfunction
 
 " FUNCTION: s:displayHelp() {{{1
 " toggles the help display
-function! s:displayHelp()
+function! s:displayHelp() abort
     call b:NERDTree.ui.toggleHelp()
     call b:NERDTree.render()
     call b:NERDTree.ui.centerView()
 endfunction
 
 " FUNCTION: s:findAndRevealPath(pathStr) {{{1
-function! s:findAndRevealPath(pathStr)
+function! s:findAndRevealPath(pathStr) abort
     let l:pathStr = !empty(a:pathStr) ? a:pathStr : expand('%:p')
     if !filereadable(l:pathStr)
         let l:pathStr = fnamemodify(l:pathStr, ':h')
@@ -333,7 +333,7 @@ endfunction
 
 "FUNCTION: s:handleLeftClick() {{{1
 "Checks if the click should open the current node
-function! s:handleLeftClick()
+function! s:handleLeftClick() abort
     let currentNode = g:NERDTreeFileNode.GetSelected()
     if currentNode !=# {}
 
@@ -368,7 +368,7 @@ function! s:handleLeftClick()
 endfunction
 
 " FUNCTION: s:handleMiddleMouse() {{{1
-function! s:handleMiddleMouse()
+function! s:handleMiddleMouse() abort
 
     " A middle mouse click does not automatically position the cursor as one
     " would expect. Forcing the execution of a regular left mouse click here
@@ -391,17 +391,17 @@ endfunction
 " FUNCTION: nerdtree#ui_glue#invokeKeyMap(key) {{{1
 "this is needed since I cant figure out how to invoke dict functions from a
 "key map
-function! nerdtree#ui_glue#invokeKeyMap(key)
+function! nerdtree#ui_glue#invokeKeyMap(key) abort
     call g:NERDTreeKeyMap.Invoke(a:key)
 endfunction
 
 " FUNCTION: s:jumpToFirstChild(node) {{{1
-function! s:jumpToFirstChild(node)
+function! s:jumpToFirstChild(node) abort
     call s:jumpToChild(a:node, 0)
 endfunction
 
 " FUNCTION: s:jumpToLastChild(node) {{{1
-function! s:jumpToLastChild(node)
+function! s:jumpToLastChild(node) abort
     call s:jumpToChild(a:node, 1)
 endfunction
 
@@ -411,7 +411,7 @@ endfunction
 " Args:
 " node: the node on which the cursor currently sits
 " last: 1 (true) if jumping to last child, 0 (false) if jumping to first
-function! s:jumpToChild(node, last)
+function! s:jumpToChild(node, last) abort
     let l:node = a:node.path.isDirectory ? a:node.getCascadeRoot() : a:node
 
     if l:node.isRoot()
@@ -430,7 +430,7 @@ endfunction
 " FUNCTION: s:jumpToParent(node) {{{1
 " Move the cursor to the parent of the specified node.  For a cascade, move to
 " the parent of the cascade's first node.  At the root node, do nothing.
-function! s:jumpToParent(node)
+function! s:jumpToParent(node) abort
     let l:node = a:node.path.isDirectory ? a:node.getCascadeRoot() : a:node
 
     if l:node.isRoot()
@@ -448,18 +448,18 @@ endfunction
 
 " FUNCTION: s:jumpToRoot() {{{1
 " moves the cursor to the root node
-function! s:jumpToRoot()
+function! s:jumpToRoot() abort
     call b:NERDTree.root.putCursorHere(1, 0)
     call b:NERDTree.ui.centerView()
 endfunction
 
 " FUNCTION: s:jumpToNextSibling(node) {{{1
-function! s:jumpToNextSibling(node)
+function! s:jumpToNextSibling(node) abort
     call s:jumpToSibling(a:node, 1)
 endfunction
 
 " FUNCTION: s:jumpToPrevSibling(node) {{{1
-function! s:jumpToPrevSibling(node)
+function! s:jumpToPrevSibling(node) abort
     call s:jumpToSibling(a:node, 0)
 endfunction
 
@@ -469,7 +469,7 @@ endfunction
 " Args:
 " node: the node on which the cursor currently sits
 " forward: 0 to jump to previous sibling, 1 to jump to next sibling
-function! s:jumpToSibling(node, forward)
+function! s:jumpToSibling(node, forward) abort
     let l:node = a:node.path.isDirectory ? a:node.getCascadeRoot() : a:node
     let l:sibling = l:node.findSibling(a:forward)
 
@@ -484,7 +484,7 @@ endfunction
 " FUNCTION: nerdtree#ui_glue#openBookmark(name) {{{1
 " Open the Bookmark that has the specified name. This function provides the
 " implementation for the :OpenBookmark command.
-function! nerdtree#ui_glue#openBookmark(name)
+function! nerdtree#ui_glue#openBookmark(name) abort
     try
         let l:bookmark = g:NERDTreeBookmark.BookmarkFor(a:name)
     catch /^NERDTree.BookmarkNotFoundError/
@@ -499,34 +499,34 @@ function! nerdtree#ui_glue#openBookmark(name)
 endfunction
 
 " FUNCTION: s:openHSplit(target) {{{1
-function! s:openHSplit(target)
+function! s:openHSplit(target) abort
     call a:target.activate({'where': 'h'})
 endfunction
 
 " FUNCTION: s:openVSplit(target) {{{1
-function! s:openVSplit(target)
+function! s:openVSplit(target) abort
     call a:target.activate({'where': 'v'})
 endfunction
 
 " FUNCTION: s:openExplorer(node) {{{1
-function! s:openExplorer(node)
+function! s:openExplorer(node) abort
     call a:node.openExplorer()
 endfunction
 
 " FUNCTION: s:openInNewTab(target) {{{1
-function! s:openInNewTab(target)
+function! s:openInNewTab(target) abort
     let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't'})
     call l:opener.open(a:target)
 endfunction
 
 " FUNCTION: s:openInNewTabSilent(target) {{{1
-function! s:openInNewTabSilent(target)
+function! s:openInNewTabSilent(target) abort
     let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't', 'stay': 1})
     call l:opener.open(a:target)
 endfunction
 
 " FUNCTION: s:openNodeRecursively(node) {{{1
-function! s:openNodeRecursively(node)
+function! s:openNodeRecursively(node) abort
     call nerdtree#echo('Recursively opening node. Please wait...')
     call a:node.openRecursively()
     call b:NERDTree.render()
@@ -534,7 +534,7 @@ function! s:openNodeRecursively(node)
 endfunction
 
 " FUNCTION: s:previewBookmark(bookmark) {{{1
-function! s:previewBookmark(bookmark)
+function! s:previewBookmark(bookmark) abort
     if a:bookmark.path.isDirectory
         execute 'NERDTreeFind '.a:bookmark.path.str()
     else
@@ -543,23 +543,23 @@ function! s:previewBookmark(bookmark)
 endfunction
 
 "FUNCTION: s:previewNodeCurrent(node) {{{1
-function! s:previewNodeCurrent(node)
+function! s:previewNodeCurrent(node) abort
     call a:node.open({'stay': 1, 'where': 'p', 'keepopen': 1})
 endfunction
 
 "FUNCTION: s:previewNodeHSplit(node) {{{1
-function! s:previewNodeHSplit(node)
+function! s:previewNodeHSplit(node) abort
     call a:node.open({'stay': 1, 'where': 'h', 'keepopen': 1})
 endfunction
 
 "FUNCTION: s:previewNodeVSplit(node) {{{1
-function! s:previewNodeVSplit(node)
+function! s:previewNodeVSplit(node) abort
     call a:node.open({'stay': 1, 'where': 'v', 'keepopen': 1})
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#revealBookmark(name) {{{1
 " put the cursor on the node associate with the given name
-function! nerdtree#ui_glue#revealBookmark(name)
+function! nerdtree#ui_glue#revealBookmark(name) abort
     try
         let targetNode = g:NERDTreeBookmark.GetNodeForName(a:name, 0, b:NERDTree)
         call targetNode.putCursorHere(0, 1)
@@ -571,7 +571,7 @@ endfunction
 " FUNCTION: s:refreshRoot() {{{1
 " Reloads the current root. All nodes below this will be lost and the root dir
 " will be reloaded.
-function! s:refreshRoot()
+function! s:refreshRoot() abort
     if !g:NERDTree.IsOpen()
         return
     endif
@@ -588,7 +588,7 @@ endfunction
 
 " FUNCTION: s:refreshCurrent(node) {{{1
 " refreshes the root for the current node
-function! s:refreshCurrent(node)
+function! s:refreshCurrent(node) abort
     let node = a:node
     if !node.path.isDirectory
         let node = node.parent
@@ -601,7 +601,7 @@ function! s:refreshCurrent(node)
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
-function! nerdtree#ui_glue#setupCommands()
+function! nerdtree#ui_glue#setupCommands() abort
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
@@ -614,7 +614,7 @@ function! nerdtree#ui_glue#setupCommands()
 endfunction
 
 " Function: s:SID()   {{{1
-function s:SID()
+function! s:SID() abort
     if !exists('s:sid')
         let s:sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
     endif
@@ -622,34 +622,34 @@ function s:SID()
 endfun
 
 " FUNCTION: s:showMenu(node) {{{1
-function! s:showMenu(node)
+function! s:showMenu(node) abort
     let mc = g:NERDTreeMenuController.New(g:NERDTreeMenuItem.AllEnabled())
     call mc.showMenu()
 endfunction
 
 " FUNCTION: s:toggleIgnoreFilter() {{{1
-function! s:toggleIgnoreFilter()
+function! s:toggleIgnoreFilter() abort
     call b:NERDTree.ui.toggleIgnoreFilter()
 endfunction
 
 " FUNCTION: s:toggleShowBookmarks() {{{1
-function! s:toggleShowBookmarks()
+function! s:toggleShowBookmarks() abort
     call b:NERDTree.ui.toggleShowBookmarks()
 endfunction
 
 " FUNCTION: s:toggleShowFiles() {{{1
-function! s:toggleShowFiles()
+function! s:toggleShowFiles() abort
     call b:NERDTree.ui.toggleShowFiles()
 endfunction
 
 " FUNCTION: s:toggleShowHidden() {{{1
 " toggles the display of hidden files
-function! s:toggleShowHidden()
+function! s:toggleShowHidden() abort
     call b:NERDTree.ui.toggleShowHidden()
 endfunction
 
 " FUNCTION: s:toggleZoom() {{{1
-function! s:toggleZoom()
+function! s:toggleZoom() abort
     call b:NERDTree.ui.toggleZoom()
 endfunction
 
@@ -659,7 +659,7 @@ endfunction
 " Args:
 " preserveState: if 1, the current root is left open when the new tree is
 " rendered; if 0, the current root node is closed
-function! nerdtree#ui_glue#upDir(preserveState)
+function! nerdtree#ui_glue#upDir(preserveState) abort
 
     try
         call b:NERDTree.root.cacheParent()
@@ -683,12 +683,12 @@ function! nerdtree#ui_glue#upDir(preserveState)
 endfunction
 
 " FUNCTION: s:upDirCurrentRootOpen() {{{1
-function! s:upDirCurrentRootOpen()
+function! s:upDirCurrentRootOpen() abort
     call nerdtree#ui_glue#upDir(1)
 endfunction
 
 " FUNCTION: s:upDirCurrentRootClosed() {{{1
-function! s:upDirCurrentRootClosed()
+function! s:upDirCurrentRootClosed() abort
     call nerdtree#ui_glue#upDir(0)
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -146,7 +146,7 @@ endfunction
 " Associate the current node with the given name
 function! nerdtree#ui_glue#bookmarkNode(...)
     let currentNode = g:NERDTreeFileNode.GetSelected()
-    if currentNode != {}
+    if currentNode !=# {}
         let name = a:1
         if empty(name)
             let name = currentNode.path.getLastPathComponent(0)
@@ -187,7 +187,7 @@ endfunction
 function! nerdtree#ui_glue#clearBookmarks(bookmarks)
     if a:bookmarks ==# ''
         let currentNode = g:NERDTreeFileNode.GetSelected()
-        if currentNode != {}
+        if currentNode !=# {}
             call currentNode.clearBookmarks()
         endif
     else
@@ -236,7 +236,7 @@ endfunction
 " FUNCTION: s:closeTreeWindow() {{{1
 " close the tree window
 function! s:closeTreeWindow()
-    if b:NERDTree.isWinTree() && b:NERDTree.previousBuf() != -1
+    if b:NERDTree.isWinTree() && b:NERDTree.previousBuf() !=# -1
         exec 'buffer ' . b:NERDTree.previousBuf()
     else
         if winnr('$') > 1
@@ -258,7 +258,7 @@ function! s:deleteBookmark(bookmark)
     echo | redraw
     let l:selection = confirm(l:message, l:choices, 1, 'Warning')
 
-    if l:selection != 1
+    if l:selection !=# 1
         call nerdtree#echo('bookmark not deleted')
         return
     endif
@@ -335,7 +335,7 @@ endfunction
 "Checks if the click should open the current node
 function! s:handleLeftClick()
     let currentNode = g:NERDTreeFileNode.GetSelected()
-    if currentNode != {}
+    if currentNode !=# {}
 
         "the dir arrows are multibyte chars, and vim's string functions only
         "deal with single bytes - so split the line up with the hack below and

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -1,4 +1,4 @@
-if exists("g:loaded_nerdtree_ui_glue_autoload")
+if exists('g:loaded_nerdtree_ui_glue_autoload')
     finish
 endif
 let g:loaded_nerdtree_ui_glue_autoload = 1
@@ -8,73 +8,73 @@ function! nerdtree#ui_glue#createDefaultBindings()
     let s = '<SNR>' . s:SID() . '_'
 
     call NERDTreeAddKeyMap({ 'key': '<MiddleMouse>', 'scope': 'all', 'callback': s . 'handleMiddleMouse' })
-    call NERDTreeAddKeyMap({ 'key': '<LeftRelease>', 'scope': "all", 'callback': s."handleLeftClick" })
-    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "DirNode", 'callback': s."activateDirNode" })
-    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "FileNode", 'callback': s."activateFileNode" })
-    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "Bookmark", 'callback': s."activateBookmark" })
-    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "all", 'callback': s."activateAll" })
+    call NERDTreeAddKeyMap({ 'key': '<LeftRelease>', 'scope': 'all', 'callback': s.'handleLeftClick' })
+    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': 'DirNode', 'callback': s.'activateDirNode' })
+    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': 'FileNode', 'callback': s.'activateFileNode' })
+    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': 'Bookmark', 'callback': s.'activateBookmark' })
+    call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': 'all', 'callback': s.'activateAll' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s."customOpenFile"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s."customOpenDir"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s."customOpenBookmark"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'all', 'callback': s."activateAll" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s.'customOpenFile'})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s.'customOpenDir'})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s.'customOpenBookmark'})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'all', 'callback': s.'activateAll' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "Bookmark", 'callback': s."activateBookmark" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': "Bookmark", 'callback': s."previewBookmark" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "all", 'callback': s."activateAll" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': 'DirNode', 'callback': s.'activateDirNode' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': 'FileNode', 'callback': s.'activateFileNode' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': 'Bookmark', 'callback': s.'activateBookmark' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': 'Bookmark', 'callback': s.'previewBookmark' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': 'all', 'callback': s.'activateAll' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenSplit, 'scope': "Node", 'callback': s."openHSplit" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenVSplit, 'scope': "Node", 'callback': s."openVSplit" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenSplit, 'scope': 'Node', 'callback': s.'openHSplit' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenVSplit, 'scope': 'Node', 'callback': s.'openVSplit' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': "Node", 'callback': s."previewNodeCurrent" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewVSplit, 'scope': "Node", 'callback': s."previewNodeVSplit" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewSplit, 'scope': "Node", 'callback': s."previewNodeHSplit" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': 'Node', 'callback': s.'previewNodeCurrent' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewVSplit, 'scope': 'Node', 'callback': s.'previewNodeVSplit' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreviewSplit, 'scope': 'Node', 'callback': s.'previewNodeHSplit' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenRecursively, 'scope': "DirNode", 'callback': s."openNodeRecursively" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenRecursively, 'scope': 'DirNode', 'callback': s.'openNodeRecursively' })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUpdir, 'scope': 'all', 'callback': s . 'upDirCurrentRootClosed' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUpdirKeepOpen, 'scope': 'all', 'callback': s . 'upDirCurrentRootOpen' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapChangeRoot, 'scope': 'Node', 'callback': s . 'chRoot' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapChdir, 'scope': "Node", 'callback': s."chCwd" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapChdir, 'scope': 'Node', 'callback': s.'chCwd' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapQuit, 'scope': "all", 'callback': s."closeTreeWindow" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapQuit, 'scope': 'all', 'callback': s.'closeTreeWindow' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCWD, 'scope': "all", 'callback': "nerdtree#ui_glue#chRootCwd" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCWD, 'scope': 'all', 'callback': 'nerdtree#ui_glue#chRootCwd' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapRefreshRoot, 'scope': "all", 'callback': s."refreshRoot" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapRefresh, 'scope': "Node", 'callback': s."refreshCurrent" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapRefreshRoot, 'scope': 'all', 'callback': s.'refreshRoot' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapRefresh, 'scope': 'Node', 'callback': s.'refreshCurrent' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapHelp, 'scope': "all", 'callback': s."displayHelp" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleZoom, 'scope': "all", 'callback': s."toggleZoom" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleHidden, 'scope': "all", 'callback': s."toggleShowHidden" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleFilters, 'scope': "all", 'callback': s."toggleIgnoreFilter" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleFiles, 'scope': "all", 'callback': s."toggleShowFiles" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleBookmarks, 'scope': "all", 'callback': s."toggleShowBookmarks" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapHelp, 'scope': 'all', 'callback': s.'displayHelp' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleZoom, 'scope': 'all', 'callback': s.'toggleZoom' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleHidden, 'scope': 'all', 'callback': s.'toggleShowHidden' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleFilters, 'scope': 'all', 'callback': s.'toggleIgnoreFilter' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleFiles, 'scope': 'all', 'callback': s.'toggleShowFiles' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapToggleBookmarks, 'scope': 'all', 'callback': s.'toggleShowBookmarks' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseDir, 'scope': "Node", 'callback': s."closeCurrentDir" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseChildren, 'scope': "DirNode", 'callback': s."closeChildren" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseDir, 'scope': 'Node', 'callback': s.'closeCurrentDir' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseChildren, 'scope': 'DirNode', 'callback': s.'closeChildren' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapMenu, 'scope': "Node", 'callback': s."showMenu" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapMenu, 'scope': 'Node', 'callback': s.'showMenu' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpParent, 'scope': "Node", 'callback': s."jumpToParent" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpFirstChild, 'scope': "Node", 'callback': s."jumpToFirstChild" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpLastChild, 'scope': "Node", 'callback': s."jumpToLastChild" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpRoot, 'scope': "all", 'callback': s."jumpToRoot" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpNextSibling, 'scope': "Node", 'callback': s."jumpToNextSibling" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpPrevSibling, 'scope': "Node", 'callback': s."jumpToPrevSibling" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpParent, 'scope': 'Node', 'callback': s.'jumpToParent' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpFirstChild, 'scope': 'Node', 'callback': s.'jumpToFirstChild' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpLastChild, 'scope': 'Node', 'callback': s.'jumpToLastChild' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpRoot, 'scope': 'all', 'callback': s.'jumpToRoot' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpNextSibling, 'scope': 'Node', 'callback': s.'jumpToNextSibling' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpPrevSibling, 'scope': 'Node', 'callback': s.'jumpToPrevSibling' })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTab, 'scope': 'Node', 'callback': s . 'openInNewTab' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTabSilent, 'scope': 'Node', 'callback': s . 'openInNewTabSilent' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTab, 'scope': 'Bookmark', 'callback': s . 'openInNewTab' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTabSilent, 'scope': 'Bookmark', 'callback': s . 'openInNewTabSilent' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenExpl, 'scope': "DirNode", 'callback': s."openExplorer" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenExpl, 'scope': "FileNode", 'callback': s."openExplorer" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenExpl, 'scope': 'DirNode', 'callback': s.'openExplorer' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenExpl, 'scope': 'FileNode', 'callback': s.'openExplorer' })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapDeleteBookmark, 'scope': "Bookmark", 'callback': s."deleteBookmark" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapDeleteBookmark, 'scope': 'Bookmark', 'callback': s.'deleteBookmark' })
 endfunction
 
 
@@ -82,19 +82,19 @@ endfunction
 "============================================================
 
 "FUNCTION: s:customOpenFile() {{{1
-" Open file node with the "custom" key, initially <CR>.
+" Open file node with the 'custom' key, initially <CR>.
 function! s:customOpenFile(node)
     call a:node.activate(s:initCustomOpenArgs().file)
 endfunction
 
 "FUNCTION: s:customOpenDir() {{{1
-" Open directory node with the "custom" key, initially <CR>.
+" Open directory node with the 'custom' key, initially <CR>.
 function! s:customOpenDir(node)
     call s:activateDirNode(a:node, s:initCustomOpenArgs().dir)
 endfunction
 
 "FUNCTION: s:customOpenBookmark() {{{1
-" Open bookmark node with the "custom" key, initially <CR>.
+" Open bookmark node with the 'custom' key, initially <CR>.
 function! s:customOpenBookmark(node)
     if a:node.path.isDirectory
         call a:node.activate(b:NERDTree, s:initCustomOpenArgs().dir)
@@ -113,7 +113,7 @@ endfunction
 "FUNCTION: s:activateAll() {{{1
 "handle the user activating the updir line
 function! s:activateAll()
-    if getline(".") ==# g:NERDTreeUI.UpDirLine()
+    if getline('.') ==# g:NERDTreeUI.UpDirLine()
         return nerdtree#ui_glue#upDir(0)
     endif
 endfunction
@@ -155,10 +155,10 @@ function! nerdtree#ui_glue#bookmarkNode(...)
             call currentNode.bookmark(name)
             call b:NERDTree.render()
         catch /^NERDTree.IllegalBookmarkNameError/
-            call nerdtree#echo("bookmark names must not contain spaces")
+            call nerdtree#echo('bookmark names must not contain spaces')
         endtry
     else
-        call nerdtree#echo("select a node first")
+        call nerdtree#echo('select a node first')
     endif
 endfunction
 
@@ -167,7 +167,7 @@ function! s:chCwd(node)
     try
         call a:node.path.changeToDir()
     catch /^NERDTree.PathChangeError/
-        call nerdtree#echoWarning("could not change cwd")
+        call nerdtree#echoWarning('could not change cwd')
     endtry
 endfunction
 
@@ -237,12 +237,12 @@ endfunction
 " close the tree window
 function! s:closeTreeWindow()
     if b:NERDTree.isWinTree() && b:NERDTree.previousBuf() != -1
-        exec "buffer " . b:NERDTree.previousBuf()
+        exec 'buffer ' . b:NERDTree.previousBuf()
     else
-        if winnr("$") > 1
+        if winnr('$') > 1
             call g:NERDTree.Close()
         else
-            call nerdtree#echo("Cannot close last window")
+            call nerdtree#echo('Cannot close last window')
         endif
     endif
 endfunction
@@ -250,8 +250,8 @@ endfunction
 " FUNCTION: s:deleteBookmark(bookmark) {{{1
 " Prompt the user to confirm the deletion of the selected bookmark.
 function! s:deleteBookmark(bookmark)
-    let l:message = "Delete the bookmark \"" . a:bookmark.name
-                \ . "\" from the bookmark list?"
+    let l:message = 'Delete the bookmark "' . a:bookmark.name
+                \ . '" from the bookmark list?'
 
     let l:choices = "&Yes\n&No"
 
@@ -340,8 +340,8 @@ function! s:handleLeftClick()
         "the dir arrows are multibyte chars, and vim's string functions only
         "deal with single bytes - so split the line up with the hack below and
         "take the line substring manually
-        let line = split(getline(line(".")), '\zs')
-        let startToCur = ""
+        let line = split(getline(line('.')), '\zs')
+        let startToCur = ''
         for i in range(0,len(line)-1)
             let startToCur .= line[i]
         endfor
@@ -483,7 +483,7 @@ endfunction
 
 " FUNCTION: nerdtree#ui_glue#openBookmark(name) {{{1
 " Open the Bookmark that has the specified name. This function provides the
-" implementation for the ":OpenBookmark" command.
+" implementation for the :OpenBookmark command.
 function! nerdtree#ui_glue#openBookmark(name)
     try
         let l:bookmark = g:NERDTreeBookmark.BookmarkFor(a:name)
@@ -527,10 +527,10 @@ endfunction
 
 " FUNCTION: s:openNodeRecursively(node) {{{1
 function! s:openNodeRecursively(node)
-    call nerdtree#echo("Recursively opening node. Please wait...")
+    call nerdtree#echo('Recursively opening node. Please wait...')
     call a:node.openRecursively()
     call b:NERDTree.render()
-    call nerdtree#echo("")
+    call nerdtree#echo('')
 endfunction
 
 " FUNCTION: s:previewBookmark(bookmark) {{{1
@@ -564,7 +564,7 @@ function! nerdtree#ui_glue#revealBookmark(name)
         let targetNode = g:NERDTreeBookmark.GetNodeForName(a:name, 0, b:NERDTree)
         call targetNode.putCursorHere(0, 1)
     catch /^NERDTree.BookmarkNotFoundError/
-        call nerdtree#echo("Bookmark isnt cached under the current root")
+        call nerdtree#echo('Bookmark isnt cached under the current root')
     endtry
 endfunction
 
@@ -575,15 +575,15 @@ function! s:refreshRoot()
     if !g:NERDTree.IsOpen()
         return
     endif
-    call nerdtree#echo("Refreshing the root node. This could take a while...")
+    call nerdtree#echo('Refreshing the root node. This could take a while...')
 
     let l:curWin = winnr()
-    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w", 1)
+    call nerdtree#exec(g:NERDTree.GetWinNum() . 'wincmd w', 1)
     call b:NERDTree.root.refresh()
     call b:NERDTree.render()
     redraw
-    call nerdtree#exec(l:curWin . "wincmd w", 1)
-    call nerdtree#echo("")
+    call nerdtree#exec(l:curWin . 'wincmd w', 1)
+    call nerdtree#echo('')
 endfunction
 
 " FUNCTION: s:refreshCurrent(node) {{{1
@@ -594,10 +594,10 @@ function! s:refreshCurrent(node)
         let node = node.parent
     endif
 
-    call nerdtree#echo("Refreshing node. This could take a while...")
+    call nerdtree#echo('Refreshing node. This could take a while...')
     call node.refresh()
     call b:NERDTree.render()
-    call nerdtree#echo("")
+    call nerdtree#echo('')
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
@@ -615,7 +615,7 @@ endfunction
 
 " Function: s:SID()   {{{1
 function s:SID()
-    if !exists("s:sid")
+    if !exists('s:sid')
         let s:sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
     endif
     return s:sid

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -93,7 +93,7 @@ function! s:Bookmark.CacheBookmarks(silent)
         for i in bookmarkStrings
 
             "ignore blank lines
-            if i != ''
+            if i !=# ''
 
                 let name = substitute(i, '^\(.\{-}\) .*$', '\1', '')
                 let path = substitute(i, '^.\{-} \(.*\)$', '\1', '')
@@ -123,13 +123,13 @@ endfunction
 " option. Supports the s:Bookmark.SortBookmarksList() method.
 function! s:Bookmark.CompareBookmarksByName(firstBookmark, secondBookmark)
     let l:result = 0
-    if g:NERDTreeBookmarksSort == 1
+    if g:NERDTreeBookmarksSort ==# 1
         if a:firstBookmark.name <? a:secondBookmark.name
             let l:result = -1
         elseif a:firstBookmark.name >? a:secondBookmark.name
             let l:result = 1
         endif
-    elseif g:NERDTreeBookmarksSort == 2
+    elseif g:NERDTreeBookmarksSort ==# 2
         if a:firstBookmark.name <# a:secondBookmark.name
             let l:result = -1
         elseif a:firstBookmark.name ># a:secondBookmark.name
@@ -198,7 +198,7 @@ endfunction
 function! s:Bookmark.GetSelected()
     let line = getline('.')
     let name = substitute(line, '^>\(.\{-}\) .\+$', '\1', '')
-    if name != line
+    if name !=# line
         try
             return s:Bookmark.BookmarkFor(name)
         catch /^NERDTree.BookmarkNotFoundError/

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -33,7 +33,7 @@ endfunction
 " Class method to get all bookmarks. Lazily initializes the bookmarks global
 " variable
 function! s:Bookmark.Bookmarks()
-    if !exists("g:NERDTreeBookmarks")
+    if !exists('g:NERDTreeBookmarks')
         let g:NERDTreeBookmarks = []
     endif
     return g:NERDTreeBookmarks
@@ -53,7 +53,7 @@ endfunction
 
 " FUNCTION: Bookmark.BookmarkFor(name) {{{1
 " Class method that returns the Bookmark object having the specified name.
-" Throws "NERDTree.BookmarkNotFoundError" if no Bookmark is found.
+" Throws NERDTree.BookmarkNotFoundError if no Bookmark is found.
 function! s:Bookmark.BookmarkFor(name)
     let l:result = {}
     for l:bookmark in s:Bookmark.Bookmarks()
@@ -111,7 +111,7 @@ function! s:Bookmark.CacheBookmarks(silent)
         if invalidBookmarksFound
             call s:Bookmark.Write()
             if !a:silent
-                call nerdtree#echo(invalidBookmarksFound . " invalid bookmarks were read. See :help NERDTreeInvalidBookmarks for info.")
+                call nerdtree#echo(invalidBookmarksFound . ' invalid bookmarks were read. See :help NERDTreeInvalidBookmarks for info.')
             endif
         endif
     endif
@@ -120,7 +120,7 @@ endfunction
 " FUNCTION: Bookmark.CompareBookmarksByName(firstBookmark, secondBookmark) {{{1
 " Class method that indicates the relative position of two bookmarks when
 " placed in alphabetical order by name. Case-sensitivity is determined by an
-" option. Supports the "s:Bookmark.SortBookmarksList()" method.
+" option. Supports the s:Bookmark.SortBookmarksList() method.
 function! s:Bookmark.CompareBookmarksByName(firstBookmark, secondBookmark)
     let l:result = 0
     if g:NERDTreeBookmarksSort == 1
@@ -159,13 +159,13 @@ endfunction
 " FUNCTION: s:Edit() {{{1
 " opens the NERDTreeBookmarks file for manual editing
 function! s:Bookmark.Edit()
-    call nerdtree#exec("wincmd w", 1)
-    call nerdtree#exec("edit ".g:NERDTreeBookmarksFile, 1)
+    call nerdtree#exec('wincmd w', 1)
+    call nerdtree#exec('edit '.g:NERDTreeBookmarksFile, 1)
 endfunction
 
 " FUNCTION: Bookmark.getNode(nerdtree, searchFromAbsoluteRoot) {{{1
 " Returns the tree node object associated with this Bookmark.
-" Throws "NERDTree.BookmarkedNodeNotFoundError" if the node is not found.
+" Throws NERDTree.BookmarkedNodeNotFoundError if the node is not found.
 "
 " Args:
 " searchFromAbsoluteRoot: boolean flag, search from the highest cached node
@@ -185,8 +185,8 @@ endfunction
 
 " FUNCTION: Bookmark.GetNodeForName(name, searchFromAbsoluteRoot, nerdtree) {{{1
 " Class method that returns the tree node object for the Bookmark with the
-" given name. Throws "NERDTree.BookmarkNotFoundError" if a Bookmark with the
-" name does not exist. Throws "NERDTree.BookmarkedNodeNotFoundError" if a
+" given name. Throws NERDTree.BookmarkNotFoundError if a Bookmark with the
+" name does not exist. Throws NERDTree.BookmarkedNodeNotFoundError if a
 " tree node for the named Bookmark could not be found.
 function! s:Bookmark.GetNodeForName(name, searchFromAbsoluteRoot, nerdtree)
     let l:bookmark = s:Bookmark.BookmarkFor(a:name)
@@ -196,7 +196,7 @@ endfunction
 " FUNCTION: Bookmark.GetSelected() {{{1
 " returns the Bookmark the cursor is over, or {}
 function! s:Bookmark.GetSelected()
-    let line = getline(".")
+    let line = getline('.')
     let name = substitute(line, '^>\(.\{-}\) .\+$', '\1', '')
     if name != line
         try
@@ -212,7 +212,7 @@ endfunction
 " Class method to get all invalid bookmark strings read from the bookmarks
 " file
 function! s:Bookmark.InvalidBookmarks()
-    if !exists("g:NERDTreeInvalidBookmarks")
+    if !exists('g:NERDTreeInvalidBookmarks')
         let g:NERDTreeInvalidBookmarks = []
     endif
     return g:NERDTreeInvalidBookmarks
@@ -222,8 +222,8 @@ endfunction
 function! s:Bookmark.mustExist()
     if !self.path.exists()
         call s:Bookmark.CacheBookmarks(1)
-        throw "NERDTree.BookmarkPointsToInvalidLocationError: the bookmark \"".
-            \ self.name ."\" points to a non existing location: \"". self.path.str()
+        throw 'NERDTree.BookmarkPointsToInvalidLocationError: the bookmark "'.
+            \ self.name .'" points to a non existing location: "'. self.path.str()
     endif
 endfunction
 
@@ -231,7 +231,7 @@ endfunction
 " Create a new bookmark object with the given name and path object
 function! s:Bookmark.New(name, path)
     if a:name =~# ' '
-        throw "NERDTree.IllegalBookmarkNameError: illegal name:" . a:name
+        throw 'NERDTree.IllegalBookmarkNameError: illegal name:' . a:name
     endif
 
     let newBookmark = copy(self)
@@ -335,7 +335,7 @@ function! s:Bookmark.validate()
         return 1
     else
         call s:Bookmark.CacheBookmarks(1)
-        call nerdtree#echo(self.name . "now points to an invalid location. See :help NERDTreeInvalidBookmarks for info.")
+        call nerdtree#echo(self.name . 'now points to an invalid location. See :help NERDTreeInvalidBookmarks for info.')
         return 0
     endif
 endfunction
@@ -349,7 +349,7 @@ function! s:Bookmark.Write()
     endfor
 
     "add a blank line before the invalid ones
-    call add(bookmarkStrings, "")
+    call add(bookmarkStrings, '')
 
     for j in s:Bookmark.InvalidBookmarks()
         call add(bookmarkStrings, j)
@@ -358,7 +358,7 @@ function! s:Bookmark.Write()
     try
         call writefile(bookmarkStrings, g:NERDTreeBookmarksFile)
     catch
-        call nerdtree#echoError("Failed to write bookmarks file. Make sure g:NERDTreeBookmarksFile points to a valid location.")
+        call nerdtree#echoError('Failed to write bookmarks file. Make sure g:NERDTreeBookmarksFile points to a valid location.')
     endtry
 endfunction
 

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -292,7 +292,7 @@ endfunction
 " Get the string that should be rendered in the view for this bookmark
 function! s:Bookmark.str()
     let pathStrMaxLen = winwidth(g:NERDTree.GetWinNum()) - 4 - strdisplaywidth(self.name)
-    if &nu
+    if &number
         let pathStrMaxLen = pathStrMaxLen - &numberwidth
     endif
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -82,20 +82,20 @@ function! s:Creator.createWindowTree(dir)
     try
         let path = g:NERDTreePath.New(a:dir)
     catch /^NERDTree.InvalidArgumentsError/
-        call nerdtree#echo("Invalid directory name:" . a:dir)
+        call nerdtree#echo('Invalid directory name:' . a:dir)
         return
     endtry
 
     "we want the directory buffer to disappear when we do the :edit below
     setlocal bufhidden=wipe
 
-    let previousBuf = expand("#")
+    let previousBuf = expand('#')
 
     "we need a unique name for each window tree buffer to ensure they are
     "all independent
-    exec g:NERDTreeCreatePrefix . " edit " . self._nextBufferName()
+    exec g:NERDTreeCreatePrefix . ' edit ' . self._nextBufferName()
 
-    call self._createNERDTree(path, "window")
+    call self._createNERDTree(path, 'window')
     let b:NERDTree._previousBuf = bufnr(previousBuf)
     call self._setCommonBufOptions()
 
@@ -109,7 +109,7 @@ function! s:Creator._createNERDTree(path, type)
     let b:NERDTree = g:NERDTree.New(a:path, a:type)
 
     " TODO: This assignment is kept for compatibility reasons.  Many other
-    " plugins use "b:NERDTreeRoot" instead of "b:NERDTree.root".  Remove this
+    " plugins use b:NERDTreeRoot instead of b:NERDTree.root.  Remove this
     " assignment in the future.
     let b:NERDTreeRoot = b:NERDTree.root
 
@@ -126,9 +126,9 @@ endfunction
 function! s:Creator.createMirror()
     "get the names off all the nerd tree buffers
     let treeBufNames = []
-    for i in range(1, tabpagenr("$"))
+    for i in range(1, tabpagenr('$'))
         let nextName = self._tabpagevar(i, 'NERDTreeBufName')
-        if nextName != -1 && (!exists("t:NERDTreeBufName") || nextName != t:NERDTreeBufName)
+        if nextName != -1 && (!exists('t:NERDTreeBufName') || nextName != t:NERDTreeBufName)
             call add(treeBufNames, nextName)
         endif
     endfor
@@ -140,7 +140,7 @@ function! s:Creator.createMirror()
     let i = 0
     while i < len(treeBufNames)
         let bufName = treeBufNames[i]
-        let treeRoot = getbufvar(bufName, "NERDTree").root
+        let treeRoot = getbufvar(bufName, 'NERDTree').root
         let options[i+1 . '. ' . treeRoot.path.str() . '  (buf name: ' . bufName . ')'] = bufName
         let i = i + 1
     endwhile
@@ -148,7 +148,7 @@ function! s:Creator.createMirror()
     "work out which tree to mirror, if there is more than 1 then ask the user
     let bufferName = ''
     if len(keys(options)) > 1
-        let choices = ["Choose a tree to mirror"]
+        let choices = ['Choose a tree to mirror']
         let choices = extend(choices, sort(keys(options)))
         let choice = inputlist(choices)
         if choice < 1 || choice > len(options) || choice ==# ''
@@ -159,7 +159,7 @@ function! s:Creator.createMirror()
     elseif len(keys(options)) ==# 1
         let bufferName = values(options)[0]
     else
-        call nerdtree#echo("No trees to mirror")
+        call nerdtree#echo('No trees to mirror')
         return
     endif
 
@@ -227,7 +227,7 @@ endfunction
 " FUNCTION: s:Creator._nextBufferNumber() {{{1
 " the number to add to the nerd tree buffer name to make the buf name unique
 function! s:Creator._nextBufferNumber()
-    if !exists("s:Creator._NextBufNum")
+    if !exists('s:Creator._NextBufNum')
         let s:Creator._NextBufNum = 1
     else
         let s:Creator._NextBufNum += 1
@@ -254,7 +254,7 @@ function! s:Creator._pathForString(str)
         try
             let path = g:NERDTreePath.New(dir)
         catch /^NERDTree.InvalidArgumentsError/
-            call nerdtree#echo("No bookmark or directory found for: " . a:str)
+            call nerdtree#echo('No bookmark or directory found for: ' . a:str)
             return {}
         endtry
     endif
@@ -274,7 +274,7 @@ function! s:Creator._removeTreeBufForTab()
 
         "nerdtree buf may be mirrored/displayed elsewhere
         if self._isBufHidden(buf)
-            exec "bwipeout " . buf
+            exec 'bwipeout ' . buf
         endif
 
     endif
@@ -333,12 +333,12 @@ function! s:Creator._tabpagevar(tabnr, var)
     let old_ei = &ei
     set ei=all
 
-    exec "tabnext " . a:tabnr
+    exec 'tabnext ' . a:tabnr
     let v = -1
     if exists('t:' . a:var)
         exec 'let v = t:' . a:var
     endif
-    exec "tabnext " . currentTab
+    exec 'tabnext ' . currentTab
 
     let &ei = old_ei
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -82,7 +82,7 @@ function! s:Creator.createWindowTree(dir)
     try
         let path = g:NERDTreePath.New(a:dir)
     catch /^NERDTree.InvalidArgumentsError/
-        call nerdtree#echo("Invalid directory name:" . a:name)
+        call nerdtree#echo("Invalid directory name:" . a:dir)
         return
     endtry
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -300,11 +300,11 @@ function! s:Creator._setCommonBufOptions()
     setlocal nowrap
 
     if g:NERDTreeShowLineNumbers
-        setlocal nu
+        setlocal number
     else
-        setlocal nonu
+        setlocal nonumber
         if v:version >= 703
-            setlocal nornu
+            setlocal norelativenumber
         endif
     endif
 
@@ -330,8 +330,8 @@ endfunction
 " FUNCTION: s:Creator._tabpagevar(tabnr, var) {{{1
 function! s:Creator._tabpagevar(tabnr, var)
     let currentTab = tabpagenr()
-    let old_ei = &ei
-    set ei=all
+    let old_ei = &eventignore
+    set eventignore=all
 
     exec 'tabnext ' . a:tabnr
     let v = -1
@@ -340,7 +340,7 @@ function! s:Creator._tabpagevar(tabnr, var)
     endif
     exec 'tabnext ' . currentTab
 
-    let &ei = old_ei
+    let &eventignore = old_ei
 
     return v
 endfunction

--- a/lib/nerdtree/flag_set.vim
+++ b/lib/nerdtree/flag_set.vim
@@ -43,13 +43,13 @@ endfunction
 
 "FUNCTION: FlagSet.renderToString() {{{1
 function! s:FlagSet.renderToString()
-    let flagstring = ""
+    let flagstring = ''
     for i in values(self._flags)
         let flagstring .= join(i)
     endfor
 
     if len(flagstring) == 0
-        return ""
+        return ''
     endif
 
     return '[' . flagstring . ']'

--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -53,7 +53,7 @@ function! s:KeyMap.bind()
     endif
     let keymapInvokeString = escape(keymapInvokeString, '\')
 
-    let premap = self.key == "<LeftRelease>" ? " <LeftRelease>" : " "
+    let premap = self.key == '<LeftRelease>' ? ' <LeftRelease>' : ' '
 
     exec 'nnoremap <buffer> <silent> '. self.key . premap . ':call nerdtree#ui_glue#invokeKeyMap("'. keymapInvokeString .'")<cr>'
 endfunction
@@ -66,7 +66,7 @@ endfunction
 "FUNCTION: KeyMap.invoke() {{{1
 "Call the KeyMaps callback function
 function! s:KeyMap.invoke(...)
-    let Callback = type(self.callback) == type(function("tr")) ? self.callback : function(self.callback)
+    let Callback = type(self.callback) == type(function('tr')) ? self.callback : function(self.callback)
     if a:0
         call Callback(a:1)
     else
@@ -78,11 +78,11 @@ endfunction
 "Find a keymapping for a:key and the current scope invoke it.
 "
 "Scope is determined as follows:
-"   * if the cursor is on a dir node then "DirNode"
-"   * if the cursor is on a file node then "FileNode"
-"   * if the cursor is on a bookmark then "Bookmark"
+"   * if the cursor is on a dir node then DirNode
+"   * if the cursor is on a file node then FileNode
+"   * if the cursor is on a bookmark then Bookmark
 "
-"If a keymap has the scope of "all" then it will be called if no other keymap
+"If a keymap has the scope of 'all' then it will be called if no other keymap
 "is found for a:key and the scope.
 function! s:KeyMap.Invoke(key)
 
@@ -100,7 +100,7 @@ function! s:KeyMap.Invoke(key)
 
         "try file node
         if !node.path.isDirectory
-            let km = s:KeyMap.FindFor(a:key, "FileNode")
+            let km = s:KeyMap.FindFor(a:key, 'FileNode')
             if !empty(km)
                 return km.invoke(node)
             endif
@@ -108,14 +108,14 @@ function! s:KeyMap.Invoke(key)
 
         "try dir node
         if node.path.isDirectory
-            let km = s:KeyMap.FindFor(a:key, "DirNode")
+            let km = s:KeyMap.FindFor(a:key, 'DirNode')
             if !empty(km)
                 return km.invoke(node)
             endif
         endif
 
         "try generic node
-        let km = s:KeyMap.FindFor(a:key, "Node")
+        let km = s:KeyMap.FindFor(a:key, 'Node')
         if !empty(km)
             return km.invoke(node)
         endif
@@ -125,14 +125,14 @@ function! s:KeyMap.Invoke(key)
     "try bookmark
     let bm = g:NERDTreeBookmark.GetSelected()
     if !empty(bm)
-        let km = s:KeyMap.FindFor(a:key, "Bookmark")
+        let km = s:KeyMap.FindFor(a:key, 'Bookmark')
         if !empty(km)
             return km.invoke(bm)
         endif
     endif
 
     "try all
-    let km = s:KeyMap.FindFor(a:key, "all")
+    let km = s:KeyMap.FindFor(a:key, 'all')
     if !empty(km)
         return km.invoke()
     endif

--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -53,7 +53,7 @@ function! s:KeyMap.bind()
     endif
     let keymapInvokeString = escape(keymapInvokeString, '\')
 
-    let premap = self.key == '<LeftRelease>' ? ' <LeftRelease>' : ' '
+    let premap = self.key ==# '<LeftRelease>' ? ' <LeftRelease>' : ' '
 
     exec 'nnoremap <buffer> <silent> '. self.key . premap . ':call nerdtree#ui_glue#invokeKeyMap("'. keymapInvokeString .'")<cr>'
 endfunction
@@ -66,7 +66,7 @@ endfunction
 "FUNCTION: KeyMap.invoke() {{{1
 "Call the KeyMaps callback function
 function! s:KeyMap.invoke(...)
-    let Callback = type(self.callback) == type(function('tr')) ? self.callback : function(self.callback)
+    let Callback = type(self.callback) ==# type(function('tr')) ? self.callback : function(self.callback)
     if a:0
         call Callback(a:1)
     else
@@ -143,7 +143,7 @@ function! s:KeyMap.Create(options)
     let opts = extend({'scope': 'all', 'quickhelpText': ''}, copy(a:options))
 
     "dont override other mappings unless the 'override' option is given
-    if get(opts, 'override', 0) == 0 && !empty(s:KeyMap.FindFor(opts['key'], opts['scope']))
+    if get(opts, 'override', 0) ==# 0 && !empty(s:KeyMap.FindFor(opts['key'], opts['scope']))
         return
     end
 

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -45,12 +45,12 @@ function! s:MenuController.showMenu()
         call self._restoreOptions()
 
         " Redraw when Ctrl-C or Esc is received.
-        if !l:done || self.selection == -1
+        if !l:done || self.selection ==# -1
             redraw!
         endif
     endtry
 
-    if self.selection != -1
+    if self.selection !=# -1
         let l:m = self._current()
         call l:m.execute()
     endif
@@ -73,7 +73,7 @@ function! s:MenuController._echoPrompt()
         echo '========================================================='
 
         for i in range(0, len(self.menuItems)-1)
-            if self.selection == i
+            if self.selection ==# i
                 echo '> ' . self.menuItems[i].text
             else
                 echo '  ' . self.menuItems[i].text
@@ -92,20 +92,20 @@ endfunction
 "change the selection (if appropriate) and return 1 if the user has made
 "their choice, 0 otherwise
 function! s:MenuController._handleKeypress(key)
-    if a:key == g:NERDTreeMenuDown
+    if a:key ==# g:NERDTreeMenuDown
         call self._cursorDown()
-    elseif a:key == g:NERDTreeMenuUp
+    elseif a:key ==# g:NERDTreeMenuUp
         call self._cursorUp()
-    elseif a:key == nr2char(27) "escape
+    elseif a:key ==# nr2char(27) "escape
         let self.selection = -1
         return 1
-    elseif a:key == "\r" || a:key == "\n" "enter and ctrl-j
+    elseif a:key ==# "\r" || a:key ==# "\n" "enter and ctrl-j
         return 1
     else
         let index = self._nextIndexFor(a:key)
-        if index != -1
+        if index !=# -1
             let self.selection = index
-            if len(self._allIndexesFor(a:key)) == 1
+            if len(self._allIndexesFor(a:key)) ==# 1
                 return 1
             endif
         endif
@@ -120,7 +120,7 @@ function! s:MenuController._allIndexesFor(shortcut)
     let toReturn = []
 
     for i in range(0, len(self.menuItems)-1)
-        if self.menuItems[i].shortcut == a:shortcut
+        if self.menuItems[i].shortcut ==# a:shortcut
             call add(toReturn, i)
         endif
     endfor
@@ -133,13 +133,13 @@ endfunction
 "current cursor location and wraps around to the top again if need be
 function! s:MenuController._nextIndexFor(shortcut)
     for i in range(self.selection+1, len(self.menuItems)-1)
-        if self.menuItems[i].shortcut == a:shortcut
+        if self.menuItems[i].shortcut ==# a:shortcut
             return i
         endif
     endfor
 
     for i in range(0, self.selection)
-        if self.menuItems[i].shortcut == a:shortcut
+        if self.menuItems[i].shortcut ==# a:shortcut
             return i
         endif
     endfor

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -44,7 +44,7 @@ function! s:MenuController.showMenu()
     finally
         call self._restoreOptions()
 
-        " Redraw when "Ctrl-C" or "Esc" is received.
+        " Redraw when Ctrl-C or Esc is received.
         if !l:done || self.selection == -1
             redraw!
         endif
@@ -58,25 +58,25 @@ endfunction
 
 "FUNCTION: MenuController._echoPrompt() {{{1
 function! s:MenuController._echoPrompt()
-    let navHelp = "Use " . g:NERDTreeMenuDown . "/" . g:NERDTreeMenuUp . "/enter"
+    let navHelp = 'Use ' . g:NERDTreeMenuDown . '/' . g:NERDTreeMenuUp . '/enter'
 
     if self.isMinimal()
         let selection = self.menuItems[self.selection].text
-        let keyword = matchstr(selection, "\([^ ]*")
+        let keyword = matchstr(selection, '\([^ ]*')
 
         let shortcuts = map(copy(self.menuItems), "v:val['shortcut']")
-        let shortcuts[self.selection] = " " . keyword . " "
+        let shortcuts[self.selection] = ' ' . keyword . ' '
 
-        echo "Menu: [" . join(shortcuts, ",") . "] (" . navHelp . " or shortcut): "
+        echo 'Menu: [' . join(shortcuts, ',') . '] (' . navHelp . ' or shortcut): '
     else
-        echo "NERDTree Menu. " . navHelp . ", or the shortcuts indicated"
-        echo "========================================================="
+        echo 'NERDTree Menu. ' . navHelp . ', or the shortcuts indicated'
+        echo '========================================================='
 
         for i in range(0, len(self.menuItems)-1)
             if self.selection == i
-                echo "> " . self.menuItems[i].text
+                echo '> ' . self.menuItems[i].text
             else
-                echo "  " . self.menuItems[i].text
+                echo '  ' . self.menuItems[i].text
             endif
         endfor
     endif

--- a/lib/nerdtree/menu_item.vim
+++ b/lib/nerdtree/menu_item.vim
@@ -6,7 +6,7 @@ let g:NERDTreeMenuItem = s:MenuItem
 "FUNCTION: MenuItem.All() {{{1
 "get all top level menu items
 function! s:MenuItem.All()
-    if !exists("s:menuItems")
+    if !exists('s:menuItems')
         let s:menuItems = []
     endif
     return s:menuItems
@@ -58,7 +58,7 @@ function! s:MenuItem.CreateSeparator(options)
     let standard_options = { 'text': '--------------------',
                 \ 'shortcut': -1,
                 \ 'callback': -1 }
-    let options = extend(a:options, standard_options, "force")
+    let options = extend(a:options, standard_options, 'force')
 
     return s:MenuItem.Create(options)
 endfunction
@@ -67,7 +67,7 @@ endfunction
 "make a new submenu and add it to global list
 function! s:MenuItem.CreateSubmenu(options)
     let standard_options = { 'callback': -1 }
-    let options = extend(a:options, standard_options, "force")
+    let options = extend(a:options, standard_options, 'force')
 
     return s:MenuItem.Create(options)
 endfunction
@@ -79,7 +79,7 @@ endfunction
 "specified
 function! s:MenuItem.enabled()
     if self.isActiveCallback != -1
-        return type(self.isActiveCallback) == type(function("tr")) ? self.isActiveCallback() : {self.isActiveCallback}()
+        return type(self.isActiveCallback) == type(function('tr')) ? self.isActiveCallback() : {self.isActiveCallback}()
     endif
     return 1
 endfunction
@@ -94,7 +94,7 @@ function! s:MenuItem.execute()
         call mc.showMenu()
     else
         if self.callback != -1
-            if type(self.callback) == type(function("tr"))
+            if type(self.callback) == type(function('tr'))
                 call self.callback()
             else
                 call {self.callback}()

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -37,26 +37,26 @@ function! s:NERDTree.Close()
         return
     endif
 
-    if winnr("$") != 1
+    if winnr('$') != 1
         " Use the window ID to identify the currently active window or fall
         " back on the buffer ID if win_getid/win_gotoid are not available, in
         " which case we'll focus an arbitrary window showing the buffer.
         let l:useWinId = exists('*win_getid') && exists('*win_gotoid')
 
         if winnr() == s:NERDTree.GetWinNum()
-            call nerdtree#exec("wincmd p", 1)
-            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
-            call nerdtree#exec("wincmd p", 1)
+            call nerdtree#exec('wincmd p', 1)
+            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr('')
+            call nerdtree#exec('wincmd p', 1)
         else
-            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
+            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr('')
         endif
 
-        call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w", 1)
-        call nerdtree#exec("close", 0)
+        call nerdtree#exec(s:NERDTree.GetWinNum() . ' wincmd w', 1)
+        call nerdtree#exec('close', 0)
         if l:useWinId
-            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")", 0)
+            call nerdtree#exec('call win_gotoid(' . l:activeBufOrWin . ')', 0)
         else
-            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w", 0)
+            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . ' wincmd w', 0)
         endif
     else
         close
@@ -75,7 +75,7 @@ endfunction
 "Places the cursor at the top of the bookmarks table
 function! s:NERDTree.CursorToBookmarkTable()
     if !b:NERDTree.ui.getShowBookmarks()
-        throw "NERDTree.IllegalOperationError: cant find bookmark table, bookmarks arent active"
+        throw 'NERDTree.IllegalOperationError: cant find bookmark table, bookmarks arent active'
     endif
 
     if g:NERDTreeMinimalUI
@@ -88,7 +88,7 @@ function! s:NERDTree.CursorToBookmarkTable()
     while getline(line) !~# '^>-\+Bookmarks-\+$'
         let line = line + 1
         if line >= rootNodeLine
-            throw "NERDTree.BookmarkTableNotFoundError: didnt find the bookmarks table"
+            throw 'NERDTree.BookmarkTableNotFoundError: didnt find the bookmarks table'
         endif
     endwhile
     call cursor(line, 2)
@@ -98,19 +98,19 @@ endfunction
 "Places the cursor in the nerd tree window
 function! s:NERDTree.CursorToTreeWin()
     call g:NERDTree.MustBeOpen()
-    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w", 1)
+    call nerdtree#exec(g:NERDTree.GetWinNum() . 'wincmd w', 1)
 endfunction
 
 " Function: s:NERDTree.ExistsForBuffer()   {{{1
 " Returns 1 if a nerd tree root exists in the current buffer
 function! s:NERDTree.ExistsForBuf()
-    return exists("b:NERDTree")
+    return exists('b:NERDTree')
 endfunction
 
 " Function: s:NERDTree.ExistsForTab()   {{{1
 " Returns 1 if a nerd tree root exists in the current tab
 function! s:NERDTree.ExistsForTab()
-    if !exists("t:NERDTreeBufName")
+    if !exists('t:NERDTreeBufName')
         return
     end
 
@@ -133,7 +133,7 @@ function! s:NERDTree.ForCurrentTab()
     endif
 
     let bufnr = bufnr(t:NERDTreeBufName)
-    return getbufvar(bufnr, "NERDTree")
+    return getbufvar(bufnr, 'NERDTree')
 endfunction
 
 "FUNCTION: s:NERDTree.getRoot() {{{1
@@ -144,7 +144,7 @@ endfunction
 "FUNCTION: s:NERDTree.GetWinNum() {{{1
 "gets the nerd tree window number for this tab
 function! s:NERDTree.GetWinNum()
-    if exists("t:NERDTreeBufName")
+    if exists('t:NERDTreeBufName')
         return bufwinnr(t:NERDTreeBufName)
     endif
 
@@ -165,18 +165,18 @@ endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1
 function! s:NERDTree.isTabTree()
-    return self._type == "tab"
+    return self._type == 'tab'
 endfunction
 
 "FUNCTION: s:NERDTree.isWinTree() {{{1
 function! s:NERDTree.isWinTree()
-    return self._type == "window"
+    return self._type == 'window'
 endfunction
 
 "FUNCTION: s:NERDTree.MustBeOpen() {{{1
 function! s:NERDTree.MustBeOpen()
     if !s:NERDTree.IsOpen()
-        throw "NERDTree.TreeNotOpen"
+        throw 'NERDTree.TreeNotOpen'
     endif
 endfunction
 

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -37,13 +37,13 @@ function! s:NERDTree.Close()
         return
     endif
 
-    if winnr('$') != 1
+    if winnr('$') !=# 1
         " Use the window ID to identify the currently active window or fall
         " back on the buffer ID if win_getid/win_gotoid are not available, in
         " which case we'll focus an arbitrary window showing the buffer.
         let l:useWinId = exists('*win_getid') && exists('*win_gotoid')
 
-        if winnr() == s:NERDTree.GetWinNum()
+        if winnr() ==# s:NERDTree.GetWinNum()
             call nerdtree#exec('wincmd p', 1)
             let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr('')
             call nerdtree#exec('wincmd p', 1)
@@ -160,17 +160,17 @@ endfunction
 
 "FUNCTION: s:NERDTree.IsOpen() {{{1
 function! s:NERDTree.IsOpen()
-    return s:NERDTree.GetWinNum() != -1
+    return s:NERDTree.GetWinNum() !=# -1
 endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1
 function! s:NERDTree.isTabTree()
-    return self._type == 'tab'
+    return self._type ==# 'tab'
 endfunction
 
 "FUNCTION: s:NERDTree.isWinTree() {{{1
 function! s:NERDTree.isWinTree()
-    return self._type == 'window'
+    return self._type ==# 'window'
 endfunction
 
 "FUNCTION: s:NERDTree.MustBeOpen() {{{1

--- a/lib/nerdtree/notifier.vim
+++ b/lib/nerdtree/notifier.vim
@@ -15,13 +15,13 @@ function! s:Notifier.NotifyListeners(event, path, nerdtree, params)
     let event = g:NERDTreeEvent.New(a:nerdtree, a:path, a:event, a:params)
 
     for Listener in s:Notifier.GetListenersForEvent(a:event)
-    	let Callback = type(Listener) == type(function("tr")) ? Listener : function(Listener)
+    	let Callback = type(Listener) == type(function('tr')) ? Listener : function(Listener)
         call Callback(event)
     endfor
 endfunction
 
 function! s:Notifier.GetListenersMap()
-    if !exists("s:refreshListenersMap")
+    if !exists('s:refreshListenersMap')
         let s:refreshListenersMap = {}
     endif
     return s:refreshListenersMap

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -45,7 +45,7 @@ function! s:Opener._checkToCloseTree(newtab)
         return
     endif
 
-    if (a:newtab && self._where == 't') || !a:newtab
+    if (a:newtab && self._where ==# 't') || !a:newtab
         call g:NERDTree.CloseIfQuitOnOpen()
     endif
 endfunction
@@ -56,7 +56,7 @@ function! s:Opener._firstUsableWindow()
     let i = 1
     while i <= winnr('$')
         let bnum = winbufnr(i)
-        if bnum != -1 && getbufvar(bnum, '&buftype') ==# ''
+        if bnum !=# -1 && getbufvar(bnum, '&buftype') ==# ''
                     \ && !getwinvar(i, '&previewwindow')
                     \ && (!getbufvar(bnum, '&modified') || &hidden)
             return i
@@ -70,23 +70,23 @@ endfunction
 " FUNCTION: Opener._gotoTargetWin() {{{1
 function! s:Opener._gotoTargetWin()
     if b:NERDTree.isWinTree()
-        if self._where == 'v'
+        if self._where ==# 'v'
             call self._newVSplit()
-        elseif self._where == 'h'
+        elseif self._where ==# 'h'
             call self._newSplit()
-        elseif self._where == 't'
+        elseif self._where ==# 't'
             tabnew
         endif
     else
         call self._checkToCloseTree(1)
 
-        if self._where == 'v'
+        if self._where ==# 'v'
             call self._newVSplit()
-        elseif self._where == 'h'
+        elseif self._where ==# 'h'
             call self._newSplit()
-        elseif self._where == 't'
+        elseif self._where ==# 't'
             tabnew
-        elseif self._where == 'p'
+        elseif self._where ==# 'p'
             call self._previousWindow()
         endif
 
@@ -108,7 +108,7 @@ function! s:Opener._isWindowUsable(winnumber)
 
     let oldwinnr = winnr()
     call nerdtree#exec(a:winnumber . 'wincmd p', 1)
-    let specialWindow = getbufvar('%', '&buftype') != '' || getwinvar('%', '&previewwindow')
+    let specialWindow = getbufvar('%', '&buftype') !=# '' || getwinvar('%', '&previewwindow')
     let modified = &modified
     call nerdtree#exec(oldwinnr . 'wincmd p', 1)
 
@@ -247,7 +247,7 @@ function! s:Opener._openDirectory(node)
     else
         if empty(self._where)
             call b:NERDTree.changeRoot(a:node)
-        elseif self._where == 't'
+        elseif self._where ==# 't'
             call g:NERDTreeCreator.CreateTabTree(a:node.path.str())
         else
             call g:NERDTreeCreator.CreateWindowTree(a:node.path.str())
@@ -296,13 +296,13 @@ function! s:Opener._reuseWindow()
 
     "check the current tab for the window
     let winnr = bufwinnr('^' . self._path.str() . '$')
-    if winnr != -1
+    if winnr !=# -1
         call nerdtree#exec(winnr . 'wincmd w', 0)
         call self._checkToCloseTree(0)
         return 1
     endif
 
-    if self._reuse == 'currenttab'
+    if self._reuse ==# 'currenttab'
         return 0
     endif
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -1,7 +1,7 @@
 " ============================================================================
 " CLASS: Opener
 "
-" The Opener class defines an API for "opening" operations.
+" The Opener class defines an API for 'opening' operations.
 " ============================================================================
 
 
@@ -54,7 +54,7 @@ endfunction
 " find the window number of the first normal window
 function! s:Opener._firstUsableWindow()
     let i = 1
-    while i <= winnr("$")
+    while i <= winnr('$')
         let bnum = winbufnr(i)
         if bnum != -1 && getbufvar(bnum, '&buftype') ==# ''
                     \ && !getwinvar(i, '&previewwindow')
@@ -102,15 +102,15 @@ endfunction
 " winnumber: the number of the window in question
 function! s:Opener._isWindowUsable(winnumber)
     "gotta split if theres only one window (i.e. the NERD tree)
-    if winnr("$") ==# 1
+    if winnr('$') ==# 1
         return 0
     endif
 
     let oldwinnr = winnr()
-    call nerdtree#exec(a:winnumber . "wincmd p", 1)
-    let specialWindow = getbufvar("%", '&buftype') != '' || getwinvar('%', '&previewwindow')
+    call nerdtree#exec(a:winnumber . 'wincmd p', 1)
+    let specialWindow = getbufvar('%', '&buftype') != '' || getwinvar('%', '&previewwindow')
     let modified = &modified
-    call nerdtree#exec(oldwinnr . "wincmd p", 1)
+    call nerdtree#exec(oldwinnr . 'wincmd p', 1)
 
     "if its a special window e.g. quickfix or another explorer plugin then we
     "have to split
@@ -131,9 +131,9 @@ endfunction
 " a:path: the path object that is to be opened
 " a:opts: a dictionary containing the following optional keys...
 "   'where': specifies whether the node should be opened in new split, in
-"            a new tab or, in the last window; takes values "v", "h", or "t"
+"            a new tab or, in the last window; takes values 'v', 'h', or 't'
 "   'reuse': if file is already shown in a window, jump there; takes values
-"            "all", "currenttab", or empty
+"            'all', 'currenttab', or empty
 "   'keepopen': boolean (0 or 1); if true, the tree window will not be closed
 "   'stay': boolean (0 or 1); if true, remain in tree window after opening
 function! s:Opener.New(path, opts)
@@ -153,21 +153,21 @@ endfunction
 
 " FUNCTION: Opener._newSplit() {{{1
 function! s:Opener._newSplit()
-    let onlyOneWin = (winnr("$") ==# 1)
+    let onlyOneWin = (winnr('$') ==# 1)
     let savesplitright = &splitright
     if onlyOneWin
-        let &splitright = (g:NERDTreeWinPos ==# "left")
+        let &splitright = (g:NERDTreeWinPos ==# 'left')
     endif
     " If only one window (ie. NERDTree), split vertically instead.
-    let splitMode = onlyOneWin ? "vertical" : ""
+    let splitMode = onlyOneWin ? 'vertical' : ''
 
     " Open the new window
     try
         call nerdtree#exec('wincmd p', 1)
-        call nerdtree#exec(splitMode . " split",1)
+        call nerdtree#exec(splitMode . ' split',1)
     catch /^Vim\%((\a\+)\)\=:E37/
         call g:NERDTree.CursorToTreeWin()
-        throw "NERDTree.FileAlreadyOpenAndModifiedError: ". self._path.str() ." is already open and modified."
+        throw 'NERDTree.FileAlreadyOpenAndModifiedError: '. self._path.str() .' is already open and modified.'
     catch /^Vim\%((\a\+)\)\=:/
         "do nothing
     endtry
@@ -187,10 +187,10 @@ endfunction
 function! s:Opener._newVSplit()
     let l:winwidth = winwidth('.')
 
-    let onlyOneWin = (winnr("$") ==# 1)
+    let onlyOneWin = (winnr('$') ==# 1)
     let savesplitright = &splitright
     if onlyOneWin
-        let &splitright = (g:NERDTreeWinPos ==# "left")
+        let &splitright = (g:NERDTreeWinPos ==# 'left')
         let l:winwidth = g:NERDTreeWinSize
     endif
 
@@ -219,7 +219,7 @@ endfunction
 
 " FUNCTION: Opener._openFile() {{{1
 function! s:Opener._openFile()
-    if !self._stay && !and(g:NERDTreeQuitOnOpen,1) && exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
+    if !self._stay && !and(g:NERDTreeQuitOnOpen,1) && exists('b:NERDTreeZoomed') && b:NERDTreeZoomed
         call b:NERDTree.ui.toggleZoom()
     endif
 
@@ -261,18 +261,18 @@ endfunction
 
 " FUNCTION: Opener._previousWindow() {{{1
 function! s:Opener._previousWindow()
-    if !self._isWindowUsable(winnr("#")) && self._firstUsableWindow() ==# -1
+    if !self._isWindowUsable(winnr('#')) && self._firstUsableWindow() ==# -1
         call self._newSplit()
     else
         try
-            if !self._isWindowUsable(winnr("#"))
-                call nerdtree#exec(self._firstUsableWindow() . "wincmd w", 1)
+            if !self._isWindowUsable(winnr('#'))
+                call nerdtree#exec(self._firstUsableWindow() . 'wincmd w', 1)
             else
                 call nerdtree#exec('wincmd p', 1)
             endif
         catch /^Vim\%((\a\+)\)\=:E37/
             call g:NERDTree.CursorToTreeWin()
-            throw "NERDTree.FileAlreadyOpenAndModifiedError: ". self._path.str() ." is already open and modified."
+            throw 'NERDTree.FileAlreadyOpenAndModifiedError: '. self._path.str() .' is already open and modified.'
         catch /^Vim\%((\a\+)\)\=:/
             echo v:exception
         endtry
@@ -297,7 +297,7 @@ function! s:Opener._reuseWindow()
     "check the current tab for the window
     let winnr = bufwinnr('^' . self._path.str() . '$')
     if winnr != -1
-        call nerdtree#exec(winnr . "wincmd w", 0)
+        call nerdtree#exec(winnr . 'wincmd w', 0)
         call self._checkToCloseTree(0)
         return 1
     endif
@@ -312,7 +312,7 @@ function! s:Opener._reuseWindow()
         call self._checkToCloseTree(1)
         call nerdtree#exec(tabnr . 'tabnext', 1)
         let winnr = bufwinnr('^' . self._path.str() . '$')
-        call nerdtree#exec(winnr . "wincmd w", 0)
+        call nerdtree#exec(winnr . 'wincmd w', 0)
         return 1
     endif
 
@@ -321,7 +321,7 @@ endfunction
 
 " FUNCTION: Opener._saveCursorPos() {{{1
 function! s:Opener._saveCursorPos()
-    let self._bufnr = bufnr("")
+    let self._bufnr = bufnr('')
     let self._tabnr = tabpagenr()
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -25,7 +25,7 @@ function! s:Path.AbsolutePathFor(pathStr)
     if l:prependWorkingDir
         let l:result = getcwd()
 
-        if l:result[-1:] == s:Path.Slash()
+        if l:result[-1:] ==# s:Path.Slash()
             let l:result = l:result . a:pathStr
         else
             let l:result = l:result . s:Path.Slash() . a:pathStr
@@ -57,7 +57,7 @@ function! s:Path.cacheDisplayString() abort
             call add(self._bookmarkNames, i.name)
         endif
     endfor
-    if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks == 1
+    if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks ==# 1
         let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' {' . join(self._bookmarkNames) . '}'
     endif
 
@@ -87,7 +87,7 @@ function! s:Path.changeToDir()
     endif
 
     try
-        if g:NERDTreeUseTCD && exists(':tcd') == 2
+        if g:NERDTreeUseTCD && exists(':tcd') ==# 2
             execute 'tcd ' . dir
             call nerdtree#echo("Tab's CWD is now: " . getcwd())
         else
@@ -201,7 +201,7 @@ function! s:Path.copy(dest)
 
     let cmd = cmd_prefix . ' ' . escape(self.str(), self._escChars()) . ' ' . escape(a:dest, self._escChars())
     let success = system(cmd)
-    if v:shell_error != 0
+    if v:shell_error !=# 0
         throw "NERDTree.CopyError: Could not copy '". self.str() ."' to: '" . a:dest . "'"
     endif
 endfunction
@@ -258,7 +258,7 @@ function! s:Path.delete()
         let cmd = g:NERDTreeRemoveDirCmd . self.str({'escape': 1})
         let success = system(cmd)
 
-        if v:shell_error != 0
+        if v:shell_error !=# 0
             throw "NERDTree.PathDeletionError: Could not delete directory: '" . self.str() . "'"
         endif
     else
@@ -269,7 +269,7 @@ function! s:Path.delete()
             let success = delete(self.str())
         endif
 
-        if success != 0
+        if success !=# 0
             throw "NERDTree.PathDeletionError: Could not delete file: '" . self.str() . "'"
         endif
     endif
@@ -303,7 +303,7 @@ endfunction
 " If running windows, cache the drive letter for this path
 function! s:Path.extractDriveLetter(fullpath)
     if nerdtree#runningWindows()
-        if a:fullpath =~ '^\(\\\\\|\/\/\)'
+        if a:fullpath =~# '^\(\\\\\|\/\/\)'
             "For network shares, the 'drive' consists of the first two parts of the path, i.e. \\boxname\share
             let self.drive = substitute(a:fullpath, '^\(\(\\\\\|\/\/\)[^\\\/]*\(\\\|\/\)[^\\\/]*\).*', '\1', '')
             let self.drive = substitute(self.drive, '/', '\', 'g')
@@ -402,7 +402,7 @@ function! s:Path._splitChunks(path)
     let i = 0
     while i < len(chunks)
         "convert number literals to numbers
-        if match(chunks[i], '^\d\+$') == 0
+        if match(chunks[i], '^\d\+$') ==# 0
             let chunks[i] = str2nr(chunks[i])
         endif
         let i = i + 1
@@ -418,16 +418,16 @@ function! s:Path.getSortKey()
         let metadata = []
         for tag in g:NERDTreeSortOrder
             if tag =~? '\[\[-\?timestamp\]\]'
-                let metadata += [self.isDirectory ? 0 : getftime(self.str()) * (tag =~ '-' ? -1 : 1)]
+                let metadata += [self.isDirectory ? 0 : getftime(self.str()) * (tag =~# '-' ? -1 : 1)]
             elseif tag =~? '\[\[-\?size\]\]'
-                let metadata += [self.isDirectory ? 0 : getfsize(self.str()) * (tag =~ '-' ? -1 : 1)]
+                let metadata += [self.isDirectory ? 0 : getfsize(self.str()) * (tag =~# '-' ? -1 : 1)]
             elseif tag =~? '\[\[extension\]\]'
                 let extension = matchstr(self.getLastPathComponent(0), '[^.]\+\.\zs[^.]\+$')
-                let metadata += [self.isDirectory ? '' : (extension == '' ? nr2char(str2nr('0x10ffff',16)) : extension)]
+                let metadata += [self.isDirectory ? '' : (extension ==# '' ? nr2char(str2nr('0x10ffff',16)) : extension)]
             endif
         endfor
 
-        if g:NERDTreeSortOrder[0] =~ '\[\[.*\]\]'
+        if g:NERDTreeSortOrder[0] =~# '\[\[.*\]\]'
             " Apply tags' sorting first if specified first.
             let self._sortKey = metadata + [self.getSortOrderIndex()]
         else
@@ -501,7 +501,7 @@ function! s:Path.ignore(nerdtree)
         endfor
 
         for Callback in g:NERDTree.PathFilters()
-            let Callback = type(Callback) == type(function('tr')) ? Callback : function(Callback)
+            let Callback = type(Callback) ==# type(function('tr')) ? Callback : function(Callback)
             if Callback({'path': self, 'nerdtree': a:nerdtree})
                 return 1
             endif
@@ -524,12 +524,12 @@ endfunction
 " returns true if this path matches the given ignore pattern
 function! s:Path._ignorePatternMatches(pattern)
     let pat = a:pattern
-    if strpart(pat,len(pat)-7) == '[[dir]]'
+    if strpart(pat,len(pat)-7) ==# '[[dir]]'
         if !self.isDirectory
             return 0
         endif
         let pat = strpart(pat,0, len(pat)-7)
-    elseif strpart(pat,len(pat)-8) == '[[file]]'
+    elseif strpart(pat,len(pat)-8) ==# '[[file]]'
         if self.isDirectory
             return 0
         endif
@@ -550,19 +550,19 @@ function! s:Path.isAncestor(path)
 
     let this = self.str()
     let that = a:path.str()
-    return stridx(that, this) == 0
+    return stridx(that, this) ==# 0
 endfunction
 
 " FUNCTION: Path.isUnder(path) {{{1
 " return 1 if this path is somewhere under the given path in the filesystem.
 function! s:Path.isUnder(path)
-    if a:path.isDirectory == 0
+    if a:path.isDirectory ==# 0
         return 0
     endif
 
     let this = self.str()
     let that = a:path.str()
-    return stridx(this, that . s:Path.Slash()) == 0
+    return stridx(this, that . s:Path.Slash()) ==# 0
 endfunction
 
 " FUNCTION: Path.JoinPathStrings(...) {{{1
@@ -665,7 +665,7 @@ function! s:Path.readInfoFromDisk(fullpath)
     let hardPath = s:Path.Resolve(self.strTrunk()) . '/' . lastPathComponent
 
     "if  the last part of the path is a symlink then flag it as such
-    let self.isSymLink = (s:Path.Resolve(hardPath) != hardPath)
+    let self.isSymLink = (s:Path.Resolve(hardPath) !=# hardPath)
     if self.isSymLink
         let self.symLinkDest = s:Path.Resolve(fullpath)
 
@@ -706,7 +706,7 @@ function! s:Path.rename(newPath)
     call s:Path.createParentDirectories(a:newPath)
 
     let success =  rename(self.str(), a:newPath)
-    if success != 0
+    if success !=# 0
         throw "NERDTree.PathRenameError: Could not rename: '" . self.str() . "'" . 'to:' . a:newPath
     endif
     call self.readInfoFromDisk(a:newPath)
@@ -779,7 +779,7 @@ endfunction
 " FUNCTION: Path._strForUI() {{{1
 function! s:Path._strForUI()
     let toReturn = '/' . join(self.pathSegments, '/')
-    if self.isDirectory && toReturn != '/'
+    if self.isDirectory && toReturn !=# '/'
         let toReturn  = toReturn . '/'
     endif
     return toReturn
@@ -802,7 +802,7 @@ function! s:Path._strForEdit()
 
     " On Windows, the drive letter may be removed by "fnamemodify()".  Add it
     " back, if necessary.
-    if nerdtree#runningWindows() && l:result[0] == s:Path.Slash()
+    if nerdtree#runningWindows() && l:result[0] ==# s:Path.Slash()
         let l:result = self.drive . l:result
     endif
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -37,7 +37,7 @@ endfunction
 
 " FUNCTION: Path.bookmarkNames() {{{1
 function! s:Path.bookmarkNames()
-    if !exists("self._bookmarkNames")
+    if !exists('self._bookmarkNames')
         call self.cacheDisplayString()
     endif
     return self._bookmarkNames
@@ -87,22 +87,22 @@ function! s:Path.changeToDir()
     endif
 
     try
-        if g:NERDTreeUseTCD && exists(":tcd") == 2
-            execute "tcd " . dir
+        if g:NERDTreeUseTCD && exists(':tcd') == 2
+            execute 'tcd ' . dir
             call nerdtree#echo("Tab's CWD is now: " . getcwd())
         else
-            execute "cd " . dir
-            call nerdtree#echo("CWD is now: " . getcwd())
+            execute 'cd ' . dir
+            call nerdtree#echo('CWD is now: ' . getcwd())
         endif
     catch
-        throw "NERDTree.PathChangeError: cannot change CWD to " . dir
+        throw 'NERDTree.PathChangeError: cannot change CWD to ' . dir
     endtry
 endfunction
 
 " FUNCTION: Path.compareTo() {{{1
 "
 " Compares this Path to the given path and returns 0 if they are equal, -1 if
-" this Path is "less than" the given path, or 1 if it is "greater".
+" this Path is 'less than' the given path, or 1 if it is 'greater'.
 "
 " Args:
 " path: the path object to compare this to
@@ -188,7 +188,7 @@ endfunction
 " dest: the location to copy this dir/file to
 function! s:Path.copy(dest)
     if !s:Path.CopyingSupported()
-        throw "NERDTree.CopyingNotSupportedError: Copying is not supported on this OS"
+        throw 'NERDTree.CopyingNotSupportedError: Copying is not supported on this OS'
     endif
 
     call s:Path.createParentDirectories(a:dest)
@@ -199,10 +199,10 @@ function! s:Path.copy(dest)
         let cmd_prefix = (self.isDirectory ? g:NERDTreeCopyDirCmd : g:NERDTreeCopyFileCmd)
     endif
 
-    let cmd = cmd_prefix . " " . escape(self.str(), self._escChars()) . " " . escape(a:dest, self._escChars())
+    let cmd = cmd_prefix . ' ' . escape(self.str(), self._escChars()) . ' ' . escape(a:dest, self._escChars())
     let success = system(cmd)
     if v:shell_error != 0
-        throw "NERDTree.CopyError: Could not copy ''". self.str() ."'' to: '" . a:dest . "'"
+        throw "NERDTree.CopyError: Could not copy '". self.str() ."' to: '" . a:dest . "'"
     endif
 endfunction
 
@@ -286,7 +286,7 @@ endfunction
 " Returns a string that specifies how the path should be represented as a
 " string
 function! s:Path.displayString()
-    if self.cachedDisplayString ==# ""
+    if self.cachedDisplayString ==# ''
         call self.cacheDisplayString()
     endif
 
@@ -295,7 +295,7 @@ endfunction
 
 " FUNCTION: Path.edit() {{{1
 function! s:Path.edit()
-    exec "edit " . self.str({'format': 'Edit'})
+    exec 'edit ' . self.str({'format': 'Edit'})
 endfunction
 
 " FUNCTION: Path.extractDriveLetter(fullpath) {{{1
@@ -306,7 +306,7 @@ function! s:Path.extractDriveLetter(fullpath)
         if a:fullpath =~ '^\(\\\\\|\/\/\)'
             "For network shares, the 'drive' consists of the first two parts of the path, i.e. \\boxname\share
             let self.drive = substitute(a:fullpath, '^\(\(\\\\\|\/\/\)[^\\\/]*\(\\\|\/\)[^\\\/]*\).*', '\1', '')
-            let self.drive = substitute(self.drive, '/', '\', "g")
+            let self.drive = substitute(self.drive, '/', '\', 'g')
         else
             let self.drive = substitute(a:fullpath, '\(^[a-zA-Z]:\).*', '\1', '')
         endif
@@ -413,7 +413,7 @@ endfunction
 " FUNCTION: Path.getSortKey() {{{1
 " returns a key used in compare function for sorting
 function! s:Path.getSortKey()
-    if !exists("self._sortKey") || g:NERDTreeSortOrder !=# g:NERDTreeOldSortOrder
+    if !exists('self._sortKey') || g:NERDTreeSortOrder !=# g:NERDTreeOldSortOrder
         " Look for file metadata tags: [[timestamp]], [[extension]], [[size]]
         let metadata = []
         for tag in g:NERDTreeSortOrder
@@ -501,7 +501,7 @@ function! s:Path.ignore(nerdtree)
         endfor
 
         for Callback in g:NERDTree.PathFilters()
-            let Callback = type(Callback) == type(function("tr")) ? Callback : function(Callback)
+            let Callback = type(Callback) == type(function('tr')) ? Callback : function(Callback)
             if Callback({'path': self, 'nerdtree': a:nerdtree})
                 return 1
             endif
@@ -637,8 +637,8 @@ function! s:Path.readInfoFromDisk(fullpath)
 
     let fullpath = s:Path.WinToUnixPath(a:fullpath)
 
-    if getftype(fullpath) ==# "fifo"
-        throw "NERDTree.InvalidFiletypeError: Cant handle FIFO files: " . a:fullpath
+    if getftype(fullpath) ==# 'fifo'
+        throw 'NERDTree.InvalidFiletypeError: Cant handle FIFO files: ' . a:fullpath
     endif
 
     let self.pathSegments = filter(split(fullpath, '/'), '!empty(v:val)')
@@ -650,7 +650,7 @@ function! s:Path.readInfoFromDisk(fullpath)
         let self.isDirectory = 0
         let self.isReadOnly = filewritable(a:fullpath) ==# 0
     else
-        throw "NERDTree.InvalidArgumentsError: Invalid path = " . a:fullpath
+        throw 'NERDTree.InvalidArgumentsError: Invalid path = ' . a:fullpath
     endif
 
     let self.isExecutable = 0
@@ -700,7 +700,7 @@ endfunction
 " Renames this node on the filesystem
 function! s:Path.rename(newPath)
     if a:newPath ==# ''
-        throw "NERDTree.InvalidArgumentsError: Invalid newPath for renaming = ". a:newPath
+        throw 'NERDTree.InvalidArgumentsError: Invalid newPath for renaming = '. a:newPath
     endif
 
     call s:Path.createParentDirectories(a:newPath)
@@ -742,7 +742,7 @@ endfunction
 " value associated with 'truncateTo'. A '<' is prepended.
 function! s:Path.str(...)
     let options = a:0 ? a:1 : {}
-    let toReturn = ""
+    let toReturn = ''
 
     if has_key(options, 'format')
         let format = options['format']
@@ -883,13 +883,13 @@ function! s:Path.WinToUnixPath(pathstr)
     let toReturn = a:pathstr
 
     "remove the x:\ of the front
-    let toReturn = substitute(toReturn, '^.*:\(\\\|/\)\?', '/', "")
+    let toReturn = substitute(toReturn, '^.*:\(\\\|/\)\?', '/', '')
 
     "remove the \\ network share from the front
-    let toReturn = substitute(toReturn, '^\(\\\\\|\/\/\)[^\\\/]*\(\\\|\/\)[^\\\/]*\(\\\|\/\)\?', '/', "")
+    let toReturn = substitute(toReturn, '^\(\\\\\|\/\/\)[^\\\/]*\(\\\|\/\)[^\\\/]*\(\\\|\/\)\?', '/', '')
 
     "convert all \ chars to /
-    let toReturn = substitute(toReturn, '\', '/', "g")
+    let toReturn = substitute(toReturn, '\', '/', 'g')
 
     return toReturn
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -218,7 +218,7 @@ endfunction
 function! s:TreeDirNode.getChildByIndex(indx, visible)
     let array_to_search = a:visible? self.getVisibleChildren() : self.children
     if a:indx > len(array_to_search)
-        throw "NERDTree.InvalidArgumentsError: Index is out of bounds."
+        throw 'NERDTree.InvalidArgumentsError: Index is out of bounds.'
     endif
     return array_to_search[a:indx]
 endfunction
@@ -255,7 +255,7 @@ function! s:TreeDirNode.getChildIndex(path)
 endfunction
 
 " FUNCTION: TreeDirNode.getDirChildren() {{{1
-" Return a list of all child nodes from "self.children" that are of type
+" Return a list of all child nodes from 'self.children' that are of type
 " TreeDirNode. This function supports http://github.com/scrooloose/nerdtree-project-plugin.git.
 function! s:TreeDirNode.getDirChildren()
     return filter(copy(self.children), 'v:val.path.isDirectory == 1')
@@ -267,7 +267,7 @@ endfunction
 "
 " Args:
 " pattern: (string) the glob pattern to apply
-" all: (0 or 1) if 1, include "." and ".." if they match "pattern"; if 0,
+" all: (0 or 1) if 1, include '.' and '..' if they match 'pattern'; if 0,
 "      always exclude them
 "
 " Note: If the pathnames in the result list are below the working directory,
@@ -276,14 +276,14 @@ endfunction
 " relative paths.
 function! s:TreeDirNode._glob(pattern, all)
 
-    " Construct a path specification such that "globpath()" will return
+    " Construct a path specification such that globpath() will return
     " relative pathnames, if possible.
     if self.path.str() == getcwd()
         let l:pathSpec = ','
     else
         let l:pathSpec = escape(fnamemodify(self.path.str({'format': 'Glob'}), ':.'), ',')
 
-        " On Windows, the drive letter may be removed by "fnamemodify()".
+        " On Windows, the drive letter may be removed by fnamemodify().
         if nerdtree#runningWindows() && l:pathSpec[0] == g:NERDTreePath.Slash()
             let l:pathSpec = self.path.drive . l:pathSpec
         endif
@@ -291,8 +291,8 @@ function! s:TreeDirNode._glob(pattern, all)
 
     let l:globList = []
 
-    " See ":h version7.txt" and ":h version8.txt" for details on the
-    " development of the "glob()" and "globpath()" functions.
+    " See ':h version7.txt' and ':h version8.txt' for details on the
+    " development of the glob() and globpath() functions.
     if v:version > 704 || (v:version == 704 && has('patch654'))
         let l:globList = globpath(l:pathSpec, a:pattern, !g:NERDTreeRespectWildIgnore, 1, 0)
     elseif v:version == 704 && has('patch279')
@@ -305,7 +305,7 @@ function! s:TreeDirNode._glob(pattern, all)
         let l:globList = split(l:globString, "\n")
     endif
 
-    " If "a:all" is false, filter "." and ".." from the output.
+    " If a:all is false, filter '.' and '..' from the output.
     if !a:all
         let l:toRemove = []
 
@@ -405,7 +405,7 @@ endfunction
 " Removes all childen from this node and re-reads them
 "
 " Args:
-" silent: 1 if the function should not echo any "please wait" messages for
+" silent: 1 if the function should not echo any 'please wait' messages for
 " large directories
 "
 " Return: the number of child nodes read
@@ -416,7 +416,7 @@ function! s:TreeDirNode._initChildren(silent)
     let files = self._glob('*', 1) + self._glob('.*', 0)
 
     if !a:silent && len(files) > g:NERDTreeNotificationThreshold
-        call nerdtree#echo("Please wait, caching a large dir ...")
+        call nerdtree#echo('Please wait, caching a large dir ...')
     endif
 
     let invalidFilesFound = 0
@@ -432,10 +432,10 @@ function! s:TreeDirNode._initChildren(silent)
 
     call self.sortChildren()
 
-    call nerdtree#echo("")
+    call nerdtree#echo('')
 
     if invalidFilesFound
-        call nerdtree#echoWarning(invalidFilesFound . " file(s) could not be loaded into the NERD tree")
+        call nerdtree#echoWarning(invalidFilesFound . ' file(s) could not be loaded into the NERD tree')
     endif
     return self.getChildCount()
 endfunction
@@ -448,7 +448,7 @@ endfunction
 " nerdtree: the tree the node belongs to
 function! s:TreeDirNode.New(path, nerdtree)
     if a:path.isDirectory != 1
-        throw "NERDTree.InvalidArgumentsError: A TreeDirNode object must be instantiated with a directory Path object."
+        throw 'NERDTree.InvalidArgumentsError: A TreeDirNode object must be instantiated with a directory Path object.'
     endif
 
     let newTreeNode = copy(self)
@@ -523,8 +523,8 @@ endfunction
 " Open an explorer window for this node in the previous window. The explorer
 " can be a NERDTree window or a netrw window.
 function! s:TreeDirNode.openExplorer()
-    execute "wincmd p"
-    execute "edit ".self.path.str({'format':'Edit'})
+    execute 'wincmd p'
+    execute 'edit '.self.path.str({'format':'Edit'})
 endfunction
 
 " FUNCTION: TreeDirNode.openInNewTab(options) {{{1
@@ -587,7 +587,7 @@ function! s:TreeDirNode.refresh()
         call self.sortChildren()
 
         if invalidFilesFound
-            call nerdtree#echoWarning("some files could not be loaded into the NERD tree")
+            call nerdtree#echoWarning('some files could not be loaded into the NERD tree')
         endif
     endif
 endfunction
@@ -614,7 +614,7 @@ function! s:TreeDirNode.reveal(path, ...)
     let opts = a:0 ? a:1 : {}
 
     if !a:path.isUnder(self.path)
-        throw "NERDTree.InvalidArgumentsError: " . a:path.str() . " should be under " . self.path.str()
+        throw 'NERDTree.InvalidArgumentsError: ' . a:path.str() . ' should be under ' . self.path.str()
     endif
 
     call self.open()
@@ -626,7 +626,7 @@ function! s:TreeDirNode.reveal(path, ...)
             call self.refresh()
             let n = self.findNode(a:path)
         endif
-        if has_key(opts, "open")
+        if has_key(opts, 'open')
             call n.open()
         endif
         return n
@@ -642,8 +642,8 @@ function! s:TreeDirNode.reveal(path, ...)
 endfunction
 
 " FUNCTION: TreeDirNode.removeChild(treenode) {{{1
-" Remove the given treenode from "self.children".
-" Throws "NERDTree.ChildNotFoundError" if the node is not found.
+" Remove the given treenode from self.children.
+" Throws NERDTree.ChildNotFoundError if the node is not found.
 "
 " Args:
 " treenode: the node object to remove
@@ -655,16 +655,16 @@ function! s:TreeDirNode.removeChild(treenode)
         endif
     endfor
 
-    throw "NERDTree.ChildNotFoundError: child node was not found"
+    throw 'NERDTree.ChildNotFoundError: child node was not found'
 endfunction
 
 " FUNCTION: TreeDirNode.sortChildren() {{{1
-" Sort "self.children" by alphabetical order and directory priority.
+" Sort self.children by alphabetical order and directory priority.
 function! s:TreeDirNode.sortChildren()
     if count(g:NERDTreeSortOrder, '*') < 1
         call add(g:NERDTreeSortOrder, '*')
     endif
-    let CompareFunc = function("nerdtree#compareNodesBySortKey")
+    let CompareFunc = function('nerdtree#compareNodesBySortKey')
     call sort(self.children, CompareFunc)
     let g:NERDTreeOldSortOrder = g:NERDTreeSortOrder
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -14,7 +14,7 @@ let g:NERDTreeDirNode = s:TreeDirNode
 " Class method that returns the highest cached ancestor of the current root.
 function! s:TreeDirNode.AbsoluteTreeRoot()
     let currentNode = b:NERDTree.root
-    while currentNode.parent != {}
+    while currentNode.parent !=# {}
         let currentNode = currentNode.parent
     endwhile
     return currentNode
@@ -100,7 +100,7 @@ function! s:TreeDirNode.displayString()
     let l:cascade = self.getCascade()
     for l:dirNode in l:cascade
         let l:next = l:dirNode.path.displayString()
-        let l:label .= l:label == '' ? l:next : substitute(l:next,'^.','','')
+        let l:label .= l:label ==# '' ? l:next : substitute(l:next,'^.','','')
     endfor
 
     " Select the appropriate open/closed status indicator symbol.
@@ -133,7 +133,7 @@ function! s:TreeDirNode.findNode(path)
     if self.path.isDirectory
         for i in self.children
             let retVal = i.findNode(a:path)
-            if retVal != {}
+            if retVal !=# {}
                 return retVal
             endif
         endfor
@@ -169,7 +169,7 @@ function! s:TreeDirNode.getCascadeRoot()
 
     while !empty(l:parent) && !l:parent.isRoot()
 
-        if index(l:parent.getCascade(), self) == -1
+        if index(l:parent.getCascade(), self) ==# -1
             break
         endif
 
@@ -258,7 +258,7 @@ endfunction
 " Return a list of all child nodes from 'self.children' that are of type
 " TreeDirNode. This function supports http://github.com/scrooloose/nerdtree-project-plugin.git.
 function! s:TreeDirNode.getDirChildren()
-    return filter(copy(self.children), 'v:val.path.isDirectory == 1')
+    return filter(copy(self.children), 'v:val.path.isDirectory ==# 1')
 endfunction
 
 " FUNCTION: TreeDirNode._glob(pattern, all) {{{1
@@ -278,13 +278,13 @@ function! s:TreeDirNode._glob(pattern, all)
 
     " Construct a path specification such that globpath() will return
     " relative pathnames, if possible.
-    if self.path.str() == getcwd()
+    if self.path.str() ==# getcwd()
         let l:pathSpec = ','
     else
         let l:pathSpec = escape(fnamemodify(self.path.str({'format': 'Glob'}), ':.'), ',')
 
         " On Windows, the drive letter may be removed by fnamemodify().
-        if nerdtree#runningWindows() && l:pathSpec[0] == g:NERDTreePath.Slash()
+        if nerdtree#runningWindows() && l:pathSpec[0] ==# g:NERDTreePath.Slash()
             let l:pathSpec = self.path.drive . l:pathSpec
         endif
     endif
@@ -293,11 +293,11 @@ function! s:TreeDirNode._glob(pattern, all)
 
     " See ':h version7.txt' and ':h version8.txt' for details on the
     " development of the glob() and globpath() functions.
-    if v:version > 704 || (v:version == 704 && has('patch654'))
+    if v:version > 704 || (v:version ==# 704 && has('patch654'))
         let l:globList = globpath(l:pathSpec, a:pattern, !g:NERDTreeRespectWildIgnore, 1, 0)
-    elseif v:version == 704 && has('patch279')
+    elseif v:version ==# 704 && has('patch279')
         let l:globList = globpath(l:pathSpec, a:pattern, !g:NERDTreeRespectWildIgnore, 1)
-    elseif v:version > 702 || (v:version == 702 && has('patch051'))
+    elseif v:version > 702 || (v:version ==# 702 && has('patch051'))
         let l:globString = globpath(l:pathSpec, a:pattern, !g:NERDTreeRespectWildIgnore)
         let l:globList = split(l:globString, "\n")
     else
@@ -315,13 +315,13 @@ function! s:TreeDirNode._glob(pattern, all)
             " If l:file has a trailing slash, then its :tail will be ''. Use
             " :h to drop the slash and the empty string after it; then use :t
             " to get the directory name.
-            if l:tail == ''
+            if l:tail ==# ''
                 let l:tail = fnamemodify(l:file, ':h:t')
             endif
 
-            if l:tail == '.' || l:tail == '..'
+            if l:tail ==# '.' || l:tail ==# '..'
                 call add(l:toRemove, l:file)
-                if len(l:toRemove) == 2
+                if len(l:toRemove) ==# 2
                     break
                 endif
             endif
@@ -341,7 +341,7 @@ endfunction
 unlet s:TreeDirNode.GetSelected
 function! s:TreeDirNode.GetSelected()
     let currentDir = g:NERDTreeFileNode.GetSelected()
-    if currentDir != {} && !currentDir.isRoot()
+    if currentDir !=# {} && !currentDir.isRoot()
         if currentDir.path.isDirectory ==# 0
             let currentDir = currentDir.parent
         endif
@@ -373,7 +373,7 @@ endfunction
 " FUNCTION: TreeDirNode.hasVisibleChildren() {{{1
 " returns 1 if this node has any childre, 0 otherwise..
 function! s:TreeDirNode.hasVisibleChildren()
-    return self.getVisibleChildCount() != 0
+    return self.getVisibleChildCount() !=# 0
 endfunction
 
 " FUNCTION: TreeDirNode.isCascadable() {{{1
@@ -383,7 +383,7 @@ endfunction
 "  2. If the parent is a symlink or is bookmarked, you end up with unparsable
 "     text, and NERDTree cannot get the path of any child node.
 function! s:TreeDirNode.isCascadable()
-    if g:NERDTreeCascadeSingleChildDir == 0
+    if g:NERDTreeCascadeSingleChildDir ==# 0
         return 0
     endif
 
@@ -398,7 +398,7 @@ function! s:TreeDirNode.isCascadable()
     endfor
 
     let c = self.getVisibleChildren()
-    return len(c) == 1 && c[0].path.isDirectory
+    return len(c) ==# 1 && c[0].path.isDirectory
 endfunction
 
 " FUNCTION: TreeDirNode._initChildren() {{{1
@@ -447,7 +447,7 @@ endfunction
 " path: dir that the node represents
 " nerdtree: the tree the node belongs to
 function! s:TreeDirNode.New(path, nerdtree)
-    if a:path.isDirectory != 1
+    if a:path.isDirectory !=# 1
         throw 'NERDTree.InvalidArgumentsError: A TreeDirNode object must be instantiated with a directory Path object.'
     endif
 
@@ -510,7 +510,7 @@ function! s:TreeDirNode.openAlong(...)
     while node.path.isDirectory
         call node.open(opts)
         let level += 1
-        if node.getVisibleChildCount() == 1
+        if node.getVisibleChildCount() ==# 1
             let node = node.getChildByIndex(0, 1)
         else
             break
@@ -567,7 +567,7 @@ function! s:TreeDirNode.refresh()
                 "create a new path and see if it exists in this nodes children
                 let path = g:NERDTreePath.New(i)
                 let newNode = self.getChild(path)
-                if newNode != {}
+                if newNode !=# {}
                     call newNode.refresh()
                     call add(newChildNodes, newNode)
 
@@ -622,7 +622,7 @@ function! s:TreeDirNode.reveal(path, ...)
     if self.path.equals(a:path.getParent())
         let n = self.findNode(a:path)
         " We may be looking for a newly-saved file that isn't in the tree yet.
-        if n == {}
+        if n ==# {}
             call self.refresh()
             let n = self.findNode(a:path)
         endif
@@ -676,7 +676,7 @@ function! s:TreeDirNode.toggleOpen(...)
     if self.isOpen ==# 1
         call self.close()
     else
-        if g:NERDTreeCascadeOpenSingleChildDir == 0
+        if g:NERDTreeCascadeOpenSingleChildDir ==# 0
             call self.open(opts)
         else
             call self.openAlong(opts)

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -1,7 +1,7 @@
 " ============================================================================
 " CLASS: TreeFileNode
 "
-" This class is the parent of the "TreeDirNode" class and is the "Component"
+" This class is the parent of the TreeDirNode class and is the 'Component'
 " part of the composite design pattern between the NERDTree node classes.
 " ============================================================================
 
@@ -42,7 +42,7 @@ function! s:TreeFileNode.cacheParent()
     if empty(self.parent)
         let parentPath = self.path.getParent()
         if parentPath.equals(self.path)
-            throw "NERDTree.CannotCacheParentError: already at root"
+            throw 'NERDTree.CannotCacheParentError: already at root'
         endif
         let self.parent = s:TreeFileNode.New(parentPath, self.getNerdtree())
     endif
@@ -195,7 +195,7 @@ endfunction
 " FUNCTION: TreeFileNode.isRoot() {{{1
 function! s:TreeFileNode.isRoot()
     if !g:NERDTree.ExistsForBuf()
-        throw "NERDTree.NoTreeError: No tree exists for the current buffer"
+        throw 'NERDTree.NoTreeError: No tree exists for the current buffer'
     endif
 
     return self.equals(self.getNerdtree().root)
@@ -248,8 +248,8 @@ endfunction
 
 " FUNCTION: TreeFileNode.openExplorer()
 function! s:TreeFileNode.openExplorer()
-    execute "wincmd p"
-    execute "edit ".self.path.getParent().str({'format':'Edit'})
+    execute 'wincmd p'
+    execute 'edit '.self.path.getParent().str({'format':'Edit'})
 endfunction
 
 " FUNCTION: TreeFileNode.putCursorHere(isJump, recurseUpward){{{1
@@ -265,7 +265,7 @@ function! s:TreeFileNode.putCursorHere(isJump, recurseUpward)
         if a:isJump
             mark '
         endif
-        call cursor(ln, col("."))
+        call cursor(ln, col('.'))
     else
         if a:recurseUpward
             let node = self
@@ -317,7 +317,7 @@ endfunction
 " child nodes are rendered only)
 " for each depth in the tree
 function! s:TreeFileNode._renderToString(depth, drawText)
-    let output = ""
+    let output = ''
     if a:drawText ==# 1
 
         let treeParts = repeat('  ', a:depth - 1)

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -27,94 +27,94 @@ function! s:UI._dumpHelp()
         let help  = "\" NERDTree (" . nerdtree#version() . ") quickhelp~\n"
         let help .= "\" ============================\n"
         let help .= "\" File node mappings~\n"
-        let help .= "\" ". (g:NERDTreeMouseMode ==# 3 ? "single" : "double") ."-click,\n"
+        let help .= '" '. (g:NERDTreeMouseMode ==# 3 ? 'single' : 'double') ."-click,\n"
         if self.nerdtree.isTabTree()
-            let help .= "\" ". g:NERDTreeMapActivateNode .": open in prev window\n"
+            let help .= '" '. g:NERDTreeMapActivateNode .": open in prev window\n"
         else
-            let help .= "\" ". g:NERDTreeMapActivateNode .": open in current window\n"
+            let help .= '" '. g:NERDTreeMapActivateNode .": open in current window\n"
         endif
         if self.nerdtree.isTabTree()
-            let help .= "\" ". g:NERDTreeMapPreview .": preview\n"
+            let help .= '" '. g:NERDTreeMapPreview .": preview\n"
         endif
-        let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
-        let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
+        let help .= '" '. g:NERDTreeMapOpenInTab.": open in new tab\n"
+        let help .= '" '. g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
         let help .= "\" middle-click,\n"
-        let help .= "\" ". g:NERDTreeMapOpenSplit .": open split\n"
-        let help .= "\" ". g:NERDTreeMapPreviewSplit .": preview split\n"
-        let help .= "\" ". g:NERDTreeMapOpenVSplit .": open vsplit\n"
-        let help .= "\" ". g:NERDTreeMapPreviewVSplit .": preview vsplit\n"
-        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
+        let help .= '" '. g:NERDTreeMapOpenSplit .": open split\n"
+        let help .= '" '. g:NERDTreeMapPreviewSplit .": preview split\n"
+        let help .= '" '. g:NERDTreeMapOpenVSplit .": open vsplit\n"
+        let help .= '" '. g:NERDTreeMapPreviewVSplit .": preview vsplit\n"
+        let help .= '" '. g:NERDTreeMapCustomOpen .": custom open\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Directory node mappings~\n"
-        let help .= "\" ". (g:NERDTreeMouseMode ==# 1 ? "double" : "single") ."-click,\n"
-        let help .= "\" ". g:NERDTreeMapActivateNode .": open & close node\n"
-        let help .= "\" ". g:NERDTreeMapOpenRecursively .": recursively open node\n"
-        let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
-        let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
-        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
-        let help .= "\" ". g:NERDTreeMapCloseDir .": close parent of node\n"
-        let help .= "\" ". g:NERDTreeMapCloseChildren .": close all child nodes of\n"
+        let help .= '" '. (g:NERDTreeMouseMode ==# 1 ? 'double' : 'single') ."-click,\n"
+        let help .= '" '. g:NERDTreeMapActivateNode .": open & close node\n"
+        let help .= '" '. g:NERDTreeMapOpenRecursively .": recursively open node\n"
+        let help .= '" '. g:NERDTreeMapOpenInTab.": open in new tab\n"
+        let help .= '" '. g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
+        let help .= '" '. g:NERDTreeMapCustomOpen .": custom open\n"
+        let help .= '" '. g:NERDTreeMapCloseDir .": close parent of node\n"
+        let help .= '" '. g:NERDTreeMapCloseChildren .": close all child nodes of\n"
         let help .= "\"    current node recursively\n"
         let help .= "\" middle-click,\n"
-        let help .= "\" ". g:NERDTreeMapOpenExpl.": explore selected dir\n"
+        let help .= '" '. g:NERDTreeMapOpenExpl.": explore selected dir\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Bookmark table mappings~\n"
         let help .= "\" double-click,\n"
-        let help .= "\" ". g:NERDTreeMapActivateNode .": open bookmark\n"
-        let help .= "\" ". g:NERDTreeMapPreview .": preview file\n"
-        let help .= "\" ". g:NERDTreeMapPreview .": find dir in tree\n"
-        let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
-        let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
-        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
-        let help .= "\" ". g:NERDTreeMapDeleteBookmark .": delete bookmark\n"
+        let help .= '" '. g:NERDTreeMapActivateNode .": open bookmark\n"
+        let help .= '" '. g:NERDTreeMapPreview .": preview file\n"
+        let help .= '" '. g:NERDTreeMapPreview .": find dir in tree\n"
+        let help .= '" '. g:NERDTreeMapOpenInTab.": open in new tab\n"
+        let help .= '" '. g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
+        let help .= '" '. g:NERDTreeMapCustomOpen .": custom open\n"
+        let help .= '" '. g:NERDTreeMapDeleteBookmark .": delete bookmark\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Tree navigation mappings~\n"
-        let help .= "\" ". g:NERDTreeMapJumpRoot .": go to root\n"
-        let help .= "\" ". g:NERDTreeMapJumpParent .": go to parent\n"
-        let help .= "\" ". g:NERDTreeMapJumpFirstChild  .": go to first child\n"
-        let help .= "\" ". g:NERDTreeMapJumpLastChild   .": go to last child\n"
-        let help .= "\" ". g:NERDTreeMapJumpNextSibling .": go to next sibling\n"
-        let help .= "\" ". g:NERDTreeMapJumpPrevSibling .": go to prev sibling\n"
+        let help .= '" '. g:NERDTreeMapJumpRoot .": go to root\n"
+        let help .= '" '. g:NERDTreeMapJumpParent .": go to parent\n"
+        let help .= '" '. g:NERDTreeMapJumpFirstChild  .": go to first child\n"
+        let help .= '" '. g:NERDTreeMapJumpLastChild   .": go to last child\n"
+        let help .= '" '. g:NERDTreeMapJumpNextSibling .": go to next sibling\n"
+        let help .= '" '. g:NERDTreeMapJumpPrevSibling .": go to prev sibling\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Filesystem mappings~\n"
-        let help .= "\" ". g:NERDTreeMapChangeRoot .": change tree root to the\n"
+        let help .= '" '. g:NERDTreeMapChangeRoot .": change tree root to the\n"
         let help .= "\"    selected dir\n"
-        let help .= "\" ". g:NERDTreeMapUpdir .": move tree root up a dir\n"
-        let help .= "\" ". g:NERDTreeMapUpdirKeepOpen .": move tree root up a dir\n"
+        let help .= '" '. g:NERDTreeMapUpdir .": move tree root up a dir\n"
+        let help .= '" '. g:NERDTreeMapUpdirKeepOpen .": move tree root up a dir\n"
         let help .= "\"    but leave old root open\n"
-        let help .= "\" ". g:NERDTreeMapRefresh .": refresh cursor dir\n"
-        let help .= "\" ". g:NERDTreeMapRefreshRoot .": refresh current root\n"
-        let help .= "\" ". g:NERDTreeMapMenu .": Show menu\n"
-        let help .= "\" ". g:NERDTreeMapChdir .":change the CWD to the\n"
+        let help .= '" '. g:NERDTreeMapRefresh .": refresh cursor dir\n"
+        let help .= '" '. g:NERDTreeMapRefreshRoot .": refresh current root\n"
+        let help .= '" '. g:NERDTreeMapMenu .": Show menu\n"
+        let help .= '" '. g:NERDTreeMapChdir .":change the CWD to the\n"
         let help .= "\"    selected dir\n"
-        let help .= "\" ". g:NERDTreeMapCWD .":change tree root to CWD\n"
+        let help .= '" '. g:NERDTreeMapCWD .":change tree root to CWD\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Tree filtering mappings~\n"
-        let help .= "\" ". g:NERDTreeMapToggleHidden .": hidden files (" . (self.getShowHidden() ? "on" : "off") . ")\n"
-        let help .= "\" ". g:NERDTreeMapToggleFilters .": file filters (" . (self.isIgnoreFilterEnabled() ? "on" : "off") . ")\n"
-        let help .= "\" ". g:NERDTreeMapToggleFiles .": files (" . (self.getShowFiles() ? "on" : "off") . ")\n"
-        let help .= "\" ". g:NERDTreeMapToggleBookmarks .": bookmarks (" . (self.getShowBookmarks() ? "on" : "off") . ")\n"
+        let help .= '" '. g:NERDTreeMapToggleHidden .': hidden files (' . (self.getShowHidden() ? 'on' : 'off') . ")\n"
+        let help .= '" '. g:NERDTreeMapToggleFilters .': file filters (' . (self.isIgnoreFilterEnabled() ? 'on' : 'off') . ")\n"
+        let help .= '" '. g:NERDTreeMapToggleFiles .': files (' . (self.getShowFiles() ? 'on' : 'off') . ")\n"
+        let help .= '" '. g:NERDTreeMapToggleBookmarks .': bookmarks (' . (self.getShowBookmarks() ? 'on' : 'off') . ")\n"
 
         " add quickhelp entries for each custom key map
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Custom mappings~\n"
         for i in g:NERDTreeKeyMap.All()
             if !empty(i.quickhelpText)
-                let help .= "\" ". i.key .": ". i.quickhelpText ."\n"
+                let help .= '" '. i.key .': '. i.quickhelpText ."\n"
             endif
         endfor
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Other mappings~\n"
-        let help .= "\" ". g:NERDTreeMapQuit .": Close the NERDTree window\n"
-        let help .= "\" ". g:NERDTreeMapToggleZoom .": Zoom (maximize-minimize)\n"
+        let help .= '" '. g:NERDTreeMapQuit .": Close the NERDTree window\n"
+        let help .= '" '. g:NERDTreeMapToggleZoom .": Zoom (maximize-minimize)\n"
         let help .= "\"    the NERDTree window\n"
-        let help .= "\" ". g:NERDTreeMapHelp .": toggle help\n"
+        let help .= '" '. g:NERDTreeMapHelp .": toggle help\n"
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Bookmark commands~\n"
         let help .= "\" :Bookmark [<name>]\n"
@@ -128,7 +128,7 @@ function! s:UI._dumpHelp()
         let help .= "\" :EditBookmarks\n"
         silent! put =help
     elseif !self.isMinimal()
-        let help ="\" Press ". g:NERDTreeMapHelp ." for help\n"
+        let help ='" Press '. g:NERDTreeMapHelp ." for help\n"
         silent! put =help
     endif
 endfunction
@@ -148,8 +148,8 @@ function! s:UI.New(nerdtree)
 endfunction
 
 " FUNCTION: s:UI.getPath(ln) {{{1
-" Return the "Path" object for the node that is rendered on the given line
-" number.  If the "up a dir" line is selected, return the "Path" object for
+" Return the Path object for the node that is rendered on the given line
+" number.  If the 'up a dir' line is selected, return the Path object for
 " the parent of the root.  Return the empty dictionary if the given line
 " does not reference a tree node.
 function! s:UI.getPath(ln)
@@ -174,7 +174,7 @@ function! s:UI.getPath(ln)
     " remove the tree parts and the leading space
     let curFile = self._stripMarkup(line)
 
-    let dir = ""
+    let dir = ''
     let lnum = a:ln
     while lnum > 0
         let lnum = lnum - 1
@@ -191,7 +191,7 @@ function! s:UI.getPath(ln)
             if lpindent < indent
                 let indent = indent - 1
 
-                let dir = substitute (curLineStripped,'^\\', "", "") . dir
+                let dir = substitute (curLineStripped,'^\\', '', '') . dir
                 continue
             endif
         endif
@@ -226,7 +226,7 @@ function! s:UI.getLineNum(node)
         let l:currentLine = self._stripMarkup(l:currentLine)
         let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
 
-        " Directories: If the current path "starts with" the full path, then
+        " Directories: If the current path 'starts with' the full path, then
         " either the paths are equal or the line is a cascade containing the
         " full path.
         if l:fullPath[-1:] == '/' && stridx(l:currentPath, l:fullPath) == 0
@@ -313,8 +313,8 @@ endfunction
 function! s:UI._renderBookmarks()
 
     if !self.isMinimal()
-        call setline(line(".")+1, ">----------Bookmarks----------")
-        call cursor(line(".")+1, col("."))
+        call setline(line('.')+1, '>----------Bookmarks----------')
+        call cursor(line('.')+1, col('.'))
     endif
 
     if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
@@ -322,12 +322,12 @@ function! s:UI._renderBookmarks()
     endif
 
     for i in g:NERDTreeBookmark.Bookmarks()
-        call setline(line(".")+1, i.str())
-        call cursor(line(".")+1, col("."))
+        call setline(line('.')+1, i.str())
+        call cursor(line('.')+1, col('.'))
     endfor
 
-    call setline(line(".")+1, '')
-    call cursor(line(".")+1, col("."))
+    call setline(line('.')+1, '')
+    call cursor(line('.')+1, col('.'))
 endfunction
 
 " FUNCTION: s:UI.restoreScreenState() {{{1
@@ -340,13 +340,13 @@ function! s:UI.restoreScreenState()
     if !has_key(self, '_screenState')
         return
     endif
-    call nerdtree#exec("silent vertical resize " . self._screenState['oldWindowSize'], 1)
+    call nerdtree#exec('silent vertical resize ' . self._screenState['oldWindowSize'], 1)
 
     let old_scrolloff=&scrolloff
     let &scrolloff=0
     call cursor(self._screenState['oldTopLine'], 0)
     normal! zt
-    call setpos(".", self._screenState['oldPos'])
+    call setpos('.', self._screenState['oldPos'])
     let &scrolloff=old_scrolloff
 endfunction
 
@@ -358,10 +358,10 @@ function! s:UI.saveScreenState()
     let self._screenState = {}
     try
         call g:NERDTree.CursorToTreeWin()
-        let self._screenState['oldPos'] = getpos(".")
-        let self._screenState['oldTopLine'] = line("w0")
-        let self._screenState['oldWindowSize']= winwidth("")
-        call nerdtree#exec(win . "wincmd w", 1)
+        let self._screenState['oldPos'] = getpos('.')
+        let self._screenState['oldTopLine'] = line('w0')
+        let self._screenState['oldWindowSize']= winwidth('')
+        call nerdtree#exec(win . 'wincmd w', 1)
     catch
     endtry
 endfunction
@@ -387,9 +387,9 @@ function! s:UI.render()
 
     " remember the top line of the buffer and the current line so we can
     " restore the view exactly how it was
-    let curLine = line(".")
-    let curCol = col(".")
-    let topLine = line("w0")
+    let curLine = line('.')
+    let curCol = col('.')
+    let topLine = line('w0')
 
     " delete all lines in the buffer (being careful not to clobber a register)
     silent 1,$delete _
@@ -398,8 +398,8 @@ function! s:UI.render()
 
     " delete the blank line before the help and add one after it
     if !self.isMinimal()
-        call setline(line(".")+1, "")
-        call cursor(line(".")+1, col("."))
+        call setline(line('.')+1, '')
+        call cursor(line('.')+1, col('.'))
     endif
 
     if self.getShowBookmarks()
@@ -408,14 +408,14 @@ function! s:UI.render()
 
     " add the 'up a dir' line
     if !self.isMinimal()
-        call setline(line(".")+1, s:UI.UpDirLine())
-        call cursor(line(".")+1, col("."))
+        call setline(line('.')+1, s:UI.UpDirLine())
+        call cursor(line('.')+1, col('.'))
     endif
 
     " draw the header line
     let header = self.nerdtree.root.path.str({'format': 'UI', 'truncateTo': winwidth(0)})
-    call setline(line(".")+1, header)
-    call cursor(line(".")+1, col("."))
+    call setline(line('.')+1, header)
+    call cursor(line('.')+1, col('.'))
 
     " draw the tree
     silent put =self.nerdtree.root.renderToString()
@@ -507,12 +507,12 @@ endfunction
 " FUNCTION: s:UI.toggleZoom() {{{1
 " zoom (maximize/minimize) the NERDTree window
 function! s:UI.toggleZoom()
-    if exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
-        let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
-        call nerdtree#exec("silent vertical resize ". size, 1)
+    if exists('b:NERDTreeZoomed') && b:NERDTreeZoomed
+        let size = exists('b:NERDTreeOldWindowSize') ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
+        call nerdtree#exec('silent vertical resize '. size, 1)
         let b:NERDTreeZoomed = 0
     else
-        call nerdtree#exec("vertical resize ". get(g:, 'NERDTreeWinSizeMax', ''), 1)
+        call nerdtree#exec('vertical resize '. get(g:, 'NERDTreeWinSizeMax', ''), 1)
         let b:NERDTreeZoomed = 1
     endif
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -157,7 +157,7 @@ function! s:UI.getPath(ln)
 
     let rootLine = self.getRootLineNum()
 
-    if a:ln == rootLine
+    if a:ln ==# rootLine
         return self.nerdtree.root.path
     endif
 
@@ -182,7 +182,7 @@ function! s:UI.getPath(ln)
         let curLineStripped = self._stripMarkup(curLine)
 
         " have we reached the top of the tree?
-        if lnum == rootLine
+        if lnum ==# rootLine
             let dir = self.nerdtree.root.path.str({'format': 'UI'}) . dir
             break
         endif
@@ -219,7 +219,7 @@ function! s:UI.getLineNum(node)
         let l:currentLine = getline(l:lineNumber)
         let l:indentLevel = self._indentLevelFor(l:currentLine)
 
-        if l:indentLevel != l:currentPathComponent
+        if l:indentLevel !=# l:currentPathComponent
             continue
         endif
 
@@ -229,7 +229,7 @@ function! s:UI.getLineNum(node)
         " Directories: If the current path 'starts with' the full path, then
         " either the paths are equal or the line is a cascade containing the
         " full path.
-        if l:fullPath[-1:] == '/' && stridx(l:currentPath, l:fullPath) == 0
+        if l:fullPath[-1:] ==# '/' && stridx(l:currentPath, l:fullPath) ==# 0
             return l:lineNumber
         endif
 
@@ -240,7 +240,7 @@ function! s:UI.getLineNum(node)
 
         " Otherwise: If the full path starts with the current path and the
         " current path is a directory, we add a new path component.
-        if stridx(l:fullPath, l:currentPath) == 0 && l:currentPath[-1:] == '/'
+        if stridx(l:fullPath, l:currentPath) ==# 0 && l:currentPath[-1:] ==# '/'
             let l:currentLine = substitute(l:currentLine, '/\s*$', '', '')
             call add(l:pathComponents, l:currentLine)
             let l:currentPathComponent += 1
@@ -296,7 +296,7 @@ endfunction
 
 " FUNCTION: s:UI.isIgnoreFilterEnabled() {{{1
 function! s:UI.isIgnoreFilterEnabled()
-    return self._ignoreEnabled == 1
+    return self._ignoreEnabled ==# 1
 endfunction
 
 " FUNCTION: s:UI.isMinimal() {{{1
@@ -317,7 +317,7 @@ function! s:UI._renderBookmarks()
         call cursor(line('.')+1, col('.'))
     endif
 
-    if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
+    if g:NERDTreeBookmarksSort ==# 1 || g:NERDTreeBookmarksSort ==# 2
         call g:NERDTreeBookmark.SortBookmarksList()
     endif
 
@@ -443,13 +443,13 @@ function! s:UI.renderViewSavingPosition()
 
     " go up the tree till we find a node that will be visible or till we run
     " out of nodes
-    while currentNode != {} && !currentNode.isVisible() && !currentNode.isRoot()
+    while currentNode !=# {} && !currentNode.isVisible() && !currentNode.isRoot()
         let currentNode = currentNode.parent
     endwhile
 
     call self.render()
 
-    if currentNode != {}
+    if currentNode !=# {}
         call currentNode.putCursorHere(0, 0)
     endif
 endfunction

--- a/nerdtree_plugin/exec_menuitem.vim
+++ b/nerdtree_plugin/exec_menuitem.vim
@@ -9,7 +9,7 @@
 "              See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 " ============================================================================
-if exists("g:loaded_nerdtree_exec_menuitem")
+if exists('g:loaded_nerdtree_exec_menuitem')
     finish
 endif
 let g:loaded_nerdtree_exec_menuitem = 1
@@ -35,6 +35,6 @@ function! NERDTreeExecFile()
     if cmd != ''
         exec ':!' . cmd
     else
-        echo "Aborted"
+        echo 'Aborted'
     endif
 endfunction

--- a/nerdtree_plugin/exec_menuitem.vim
+++ b/nerdtree_plugin/exec_menuitem.vim
@@ -32,7 +32,7 @@ function! NERDTreeExecFile()
     let cmd = treenode.path.str({'escape': 1})
     let cmd = input(':!', cmd . ' ')
 
-    if cmd != ''
+    if cmd !=# ''
         exec ':!' . cmd
     else
         echo 'Aborted'

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -9,13 +9,13 @@
 "              See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 " ============================================================================
-if exists("g:loaded_nerdtree_fs_menu")
+if exists('g:loaded_nerdtree_fs_menu')
     finish
 endif
 let g:loaded_nerdtree_fs_menu = 1
 
 "Automatically delete the buffer after deleting or renaming a file
-if !exists("g:NERDTreeAutoDeleteBuffer")
+if !exists('g:NERDTreeAutoDeleteBuffer')
     let g:NERDTreeAutoDeleteBuffer = 0
 endif
 
@@ -23,13 +23,13 @@ call NERDTreeAddMenuItem({'text': '(a)dd a childnode', 'shortcut': 'a', 'callbac
 call NERDTreeAddMenuItem({'text': '(m)ove the current node', 'shortcut': 'm', 'callback': 'NERDTreeMoveNode'})
 call NERDTreeAddMenuItem({'text': '(d)elete the current node', 'shortcut': 'd', 'callback': 'NERDTreeDeleteNode'})
 
-if has("gui_mac") || has("gui_macvim") || has("mac")
+if has('gui_mac') || has('gui_macvim') || has('mac')
     call NERDTreeAddMenuItem({'text': '(r)eveal in Finder the current node', 'shortcut': 'r', 'callback': 'NERDTreeRevealInFinder'})
     call NERDTreeAddMenuItem({'text': '(o)pen the current node with system editor', 'shortcut': 'o', 'callback': 'NERDTreeExecuteFile'})
     call NERDTreeAddMenuItem({'text': '(q)uicklook the current node', 'shortcut': 'q', 'callback': 'NERDTreeQuickLook'})
 endif
 
-if executable("xdg-open")
+if executable('xdg-open')
     call NERDTreeAddMenuItem({'text': '(r)eveal the current node in file manager', 'shortcut': 'r', 'callback': 'NERDTreeRevealFileLinux'})
     call NERDTreeAddMenuItem({'text': '(o)pen the current node with system editor', 'shortcut': 'o', 'callback': 'NERDTreeExecuteFileLinux'})
 endif
@@ -37,9 +37,9 @@ endif
 if g:NERDTreePath.CopyingSupported()
     call NERDTreeAddMenuItem({'text': '(c)opy the current node', 'shortcut': 'c', 'callback': 'NERDTreeCopyNode'})
 endif
-call NERDTreeAddMenuItem({'text': (has("clipboard")?'copy (p)ath to clipboard':'print (p)ath to screen'), 'shortcut': 'p', 'callback': 'NERDTreeCopyPath'})
+call NERDTreeAddMenuItem({'text': (has('clipboard')?'copy (p)ath to clipboard':'print (p)ath to screen'), 'shortcut': 'p', 'callback': 'NERDTreeCopyPath'})
 
-if has("unix") || has("osx")
+if has('unix') || has('osx')
     call NERDTreeAddMenuItem({'text': '(l)ist the current node', 'shortcut': 'l', 'callback': 'NERDTreeListNode'})
 else
     call NERDTreeAddMenuItem({'text': '(l)ist the current node', 'shortcut': 'l', 'callback': 'NERDTreeListNodeWin32'})
@@ -51,37 +51,37 @@ endif
 "Args:
 "action: the action that is being performed, e.g. 'delete'
 function! s:inputPrompt(action)
-    if a:action == "add"
-        let title = "Add a childnode"
+    if a:action == 'add'
+        let title = 'Add a childnode'
         let info = "Enter the dir/file name to be created. Dirs end with a '/'"
-        let minimal = "Add node:"
+        let minimal = 'Add node:'
 
-    elseif a:action == "copy"
-        let title = "Copy the current node"
-        let info = "Enter the new path to copy the node to:"
-        let minimal = "Copy to:"
+    elseif a:action == 'copy'
+        let title = 'Copy the current node'
+        let info = 'Enter the new path to copy the node to:'
+        let minimal = 'Copy to:'
 
-    elseif a:action == "delete"
-        let title = "Delete the current node"
-        let info = "Are you sure you wish to delete the node:"
-        let minimal = "Delete?"
+    elseif a:action == 'delete'
+        let title = 'Delete the current node'
+        let info = 'Are you sure you wish to delete the node:'
+        let minimal = 'Delete?'
 
-    elseif a:action == "deleteNonEmpty"
-        let title = "Delete the current node"
+    elseif a:action == 'deleteNonEmpty'
+        let title = 'Delete the current node'
         let info =  "STOP! Directory is not empty! To delete, type 'yes'"
-        let minimal = "Delete directory?"
+        let minimal = 'Delete directory?'
 
-    elseif a:action == "move"
-        let title = "Rename the current node"
-        let info = "Enter the new path for the node:"
-        let minimal = "Move to:"
+    elseif a:action == 'move'
+        let title = 'Rename the current node'
+        let info = 'Enter the new path for the node:'
+        let minimal = 'Move to:'
     endif
 
     if g:NERDTreeMenuController.isMinimal()
         redraw! " Clear the menu
-        return minimal . " "
+        return minimal . ' '
     else
-        let divider = "=========================================================="
+        let divider = '=========================================================='
         return title . "\n" . divider . "\n" . info . "\n"
     end
 endfunction
@@ -114,14 +114,14 @@ function! s:promptToDelBuffer(bufnum, msg)
             let l:listedBufferCount = 0
         endif
         if l:listedBufferCount > 1
-            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif", 1)
+            call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufnum . " | exec ':bnext! ' | endif", 1)
         else
-            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif", 1)
+            call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufnum . " | exec ':enew! ' | endif", 1)
         endif
-        call nerdtree#exec("tabnext " . s:originalTabNumber, 1)
-        call nerdtree#exec(s:originalWindowNumber . "wincmd w", 1)
+        call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
+        call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
         " 3. We don't need a previous buffer anymore
-        call nerdtree#exec("bwipeout! " . a:bufnum, 0)
+        call nerdtree#exec('bwipeout! ' . a:bufnum, 0)
     endif
 endfunction
 
@@ -141,17 +141,17 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
         let editStr = g:NERDTreePath.New(a:newNodeName).str({'format': 'Edit'})
     endif
     " 1. ensure that a new buffer is loaded
-    call nerdtree#exec("badd " . quotedFileName, 1)
+    call nerdtree#exec('badd ' . quotedFileName, 1)
     " 2. ensure that all windows which display the just deleted filename
     " display a buffer for a new filename.
     let s:originalTabNumber = tabpagenr()
     let s:originalWindowNumber = winnr()
-    call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufNum . " | exec ':e! " . editStr . "' | endif", 1)
-    call nerdtree#exec("tabnext " . s:originalTabNumber, 1)
-    call nerdtree#exec(s:originalWindowNumber . "wincmd w", 1)
+    call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufNum . " | exec ':e! " . editStr . "' | endif", 1)
+    call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
+    call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
     " 3. We don't need a previous buffer anymore
     try
-        call nerdtree#exec("confirm bwipeout " . a:bufNum, 0)
+        call nerdtree#exec('confirm bwipeout ' . a:bufNum, 0)
     catch
         " This happens when answering Cancel if confirmation is needed. Do nothing.
     endtry
@@ -160,11 +160,11 @@ endfunction
 "FUNCTION: NERDTreeAddNode(){{{1
 function! NERDTreeAddNode()
     let curDirNode = g:NERDTreeDirNode.GetSelected()
-    let prompt = s:inputPrompt("add")
-    let newNodeName = input(prompt, curDirNode.path.str() . g:NERDTreePath.Slash(), "file")
+    let prompt = s:inputPrompt('add')
+    let newNodeName = input(prompt, curDirNode.path.str() . g:NERDTreePath.Slash(), 'file')
 
     if newNodeName ==# ''
-        call nerdtree#echo("Node Creation Aborted.")
+        call nerdtree#echo('Node Creation Aborted.')
         return
     endif
 
@@ -187,26 +187,26 @@ function! NERDTreeAddNode()
 
         redraw!
     catch /^NERDTree/
-        call nerdtree#echoWarning("Node Not Created.")
+        call nerdtree#echoWarning('Node Not Created.')
     endtry
 endfunction
 
 "FUNCTION: NERDTreeMoveNode(){{{1
 function! NERDTreeMoveNode()
     let curNode = g:NERDTreeFileNode.GetSelected()
-    let prompt = s:inputPrompt("move")
-    let newNodePath = input(prompt, curNode.path.str(), "file")
+    let prompt = s:inputPrompt('move')
+    let newNodePath = input(prompt, curNode.path.str(), 'file')
 
     if newNodePath ==# ''
-        call nerdtree#echo("Node Renaming Aborted.")
+        call nerdtree#echo('Node Renaming Aborted.')
         return
     endif
 
     try
         if curNode.path.isDirectory
-            let l:openBuffers = filter(range(1,bufnr("$")),'bufexists(v:val) && fnamemodify(bufname(v:val),":p") =~# curNode.path.str() . "/.*"')
+            let l:openBuffers = filter(range(1,bufnr('$')),'bufexists(v:val) && fnamemodify(bufname(v:val),":p") =~# curNode.path.str() . "/.*"')
         else
-            let l:openBuffers = filter(range(1,bufnr("$")),'bufexists(v:val) && fnamemodify(bufname(v:val),":p") ==# curNode.path.str()')
+            let l:openBuffers = filter(range(1,bufnr('$')),'bufexists(v:val) && fnamemodify(bufname(v:val),":p") ==# curNode.path.str()')
         endif
 
         call curNode.rename(newNodePath)
@@ -221,9 +221,9 @@ function! NERDTreeMoveNode()
         " renamed files.
         if !empty(l:openBuffers)
             if curNode.path.isDirectory
-                echo "\nDirectory renamed.\n\nFiles with the old directory name are open in buffers " . join(l:openBuffers, ', ') . ". Replace these buffers with the new files? (yN)"
+                echo "\nDirectory renamed.\n\nFiles with the old directory name are open in buffers " . join(l:openBuffers, ', ') . '. Replace these buffers with the new files? (yN)'
             else
-                echo "\nFile renamed.\n\nThe old file is open in buffer " . l:openBuffers[0] . ". Replace this buffer with the new file? (yN)"
+                echo "\nFile renamed.\n\nThe old file is open in buffer " . l:openBuffers[0] . '. Replace this buffer with the new file? (yN)'
             endif
             if g:NERDTreeAutoDeleteBuffer || nr2char(getchar()) ==# 'y'
                 for bufNum in l:openBuffers
@@ -236,7 +236,7 @@ function! NERDTreeMoveNode()
 
         redraw!
     catch /^NERDTree/
-        call nerdtree#echoWarning("Node Not Renamed.")
+        call nerdtree#echoWarning('Node Not Renamed.')
     endtry
 endfunction
 
@@ -249,11 +249,11 @@ function! NERDTreeDeleteNode()
 
     if currentNode.path.isDirectory && ((currentNode.isOpen && currentNode.getChildCount() > 0) ||
                                       \ (len(currentNode._glob('*', 1)) > 0))
-        let prompt = s:inputPrompt("deleteNonEmpty") . currentNode.path.str() . ": "
+        let prompt = s:inputPrompt('deleteNonEmpty') . currentNode.path.str() . ': '
         let choice = input(prompt)
         let confirmed = choice ==# 'yes'
     else
-        let prompt = s:inputPrompt("delete") . currentNode.path.str() . " (yN): "
+        let prompt = s:inputPrompt('delete') . currentNode.path.str() . ' (yN): '
         echo prompt
         let choice = nr2char(getchar())
         let confirmed = choice ==# 'y'
@@ -266,18 +266,18 @@ function! NERDTreeDeleteNode()
 
             "if the node is open in a buffer, ask the user if they want to
             "close that buffer
-            let bufnum = bufnr("^".currentNode.path.str()."$")
+            let bufnum = bufnr('^'.currentNode.path.str().'$')
             if buflisted(bufnum)
-                let prompt = "\nNode deleted.\n\nThe file is open in buffer ". bufnum . (bufwinnr(bufnum) ==# -1 ? " (hidden)" : "") .". Delete this buffer? (yN)"
+                let prompt = "\nNode deleted.\n\nThe file is open in buffer ". bufnum . (bufwinnr(bufnum) ==# -1 ? ' (hidden)' : '') .'. Delete this buffer? (yN)'
                 call s:promptToDelBuffer(bufnum, prompt)
             endif
 
             redraw!
         catch /^NERDTree/
-            call nerdtree#echoWarning("Could not remove node")
+            call nerdtree#echoWarning('Could not remove node')
         endtry
     else
-        call nerdtree#echo("delete aborted")
+        call nerdtree#echo('delete aborted')
     endif
     let &shellslash = l:shellslash
 endfunction
@@ -286,10 +286,10 @@ endfunction
 function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
     if !empty(treenode)
-        let s:uname = system("uname")
+        let s:uname = system('uname')
         let stat_cmd = 'stat -c "%s" '
 
-        if s:uname =~? "Darwin"
+        if s:uname =~? 'Darwin'
             let stat_cmd = 'stat -f "%z" '
         endif
 
@@ -300,7 +300,7 @@ function! NERDTreeListNode()
         let metadata = split(system(cmd),'\n')
         call nerdtree#echo(metadata[0])
     else
-        call nerdtree#echo("No information available")
+        call nerdtree#echo('No information available')
     endif
 endfunction
 
@@ -310,10 +310,10 @@ function! NERDTreeListNodeWin32()
 
     if !empty(l:node)
         let l:path = l:node.path.str()
-        call nerdtree#echo(printf("%s:%s  MOD:%s  BYTES:%d  PERMISSIONS:%s",
+        call nerdtree#echo(printf('%s:%s  MOD:%s  BYTES:%d  PERMISSIONS:%s',
                     \ toupper(getftype(l:path)),
                     \ fnamemodify(l:path, ':t'),
-                    \ strftime("%c", getftime(l:path)),
+                    \ strftime('%c', getftime(l:path)),
                     \ getfsize(l:path),
                     \ getfperm(l:path)))
         return
@@ -327,16 +327,16 @@ function! NERDTreeCopyNode()
     let l:shellslash = &shellslash
     let &shellslash = 0
     let currentNode = g:NERDTreeFileNode.GetSelected()
-    let prompt = s:inputPrompt("copy")
-    let newNodePath = input(prompt, currentNode.path.str(), "file")
+    let prompt = s:inputPrompt('copy')
+    let newNodePath = input(prompt, currentNode.path.str(), 'file')
 
-    if newNodePath != ""
+    if newNodePath != ''
         "strip trailing slash
         let newNodePath = substitute(newNodePath, '\/$', '', '')
 
         let confirmed = 1
         if currentNode.path.copyingWillOverwrite(newNodePath)
-            call nerdtree#echo("Warning: copying may overwrite files! Continue? (yN)")
+            call nerdtree#echo('Warning: copying may overwrite files! Continue? (yN)')
             let choice = nr2char(getchar())
             let confirmed = choice ==# 'y'
         endif
@@ -355,11 +355,11 @@ function! NERDTreeCopyNode()
                     call newNode.putCursorHere(0, 0)
                 endif
             catch /^NERDTree/
-                call nerdtree#echoWarning("Could not copy node")
+                call nerdtree#echoWarning('Could not copy node')
             endtry
         endif
     else
-        call nerdtree#echo("Copy aborted.")
+        call nerdtree#echo('Copy aborted.')
     endif
     let &shellslash = l:shellslash
     redraw!
@@ -368,15 +368,15 @@ endfunction
 " FUNCTION: NERDTreeCopyPath() {{{1
 function! NERDTreeCopyPath()
     let l:nodePath = g:NERDTreeFileNode.GetSelected().path.str()
-    if has("clipboard")
-        if &clipboard == "unnamedplus"
+    if has('clipboard')
+        if &clipboard == 'unnamedplus'
             let @+ = l:nodePath
         else
             let @* = l:nodePath
         endif
-        call nerdtree#echo("The path [" . l:nodePath . "] was copied to your clipboard.")
+        call nerdtree#echo('The path [' . l:nodePath . '] was copied to your clipboard.')
     else
-        call nerdtree#echo("The full path is: " . l:nodePath)
+        call nerdtree#echo('The full path is: ' . l:nodePath)
     endif
 endfunction
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -51,27 +51,27 @@ endif
 "Args:
 "action: the action that is being performed, e.g. 'delete'
 function! s:inputPrompt(action)
-    if a:action == 'add'
+    if a:action ==# 'add'
         let title = 'Add a childnode'
         let info = "Enter the dir/file name to be created. Dirs end with a '/'"
         let minimal = 'Add node:'
 
-    elseif a:action == 'copy'
+    elseif a:action ==# 'copy'
         let title = 'Copy the current node'
         let info = 'Enter the new path to copy the node to:'
         let minimal = 'Copy to:'
 
-    elseif a:action == 'delete'
+    elseif a:action ==# 'delete'
         let title = 'Delete the current node'
         let info = 'Are you sure you wish to delete the node:'
         let minimal = 'Delete?'
 
-    elseif a:action == 'deleteNonEmpty'
+    elseif a:action ==# 'deleteNonEmpty'
         let title = 'Delete the current node'
         let info =  "STOP! Directory is not empty! To delete, type 'yes'"
         let minimal = 'Delete directory?'
 
-    elseif a:action == 'move'
+    elseif a:action ==# 'move'
         let title = 'Rename the current node'
         let info = 'Enter the new path for the node:'
         let minimal = 'Move to:'
@@ -114,9 +114,9 @@ function! s:promptToDelBuffer(bufnum, msg)
             let l:listedBufferCount = 0
         endif
         if l:listedBufferCount > 1
-            call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufnum . " | exec ':bnext! ' | endif", 1)
+            call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . a:bufnum . " | exec ':bnext! ' | endif", 1)
         else
-            call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufnum . " | exec ':enew! ' | endif", 1)
+            call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . a:bufnum . " | exec ':enew! ' | endif", 1)
         endif
         call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
         call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
@@ -146,7 +146,7 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
     " display a buffer for a new filename.
     let s:originalTabNumber = tabpagenr()
     let s:originalWindowNumber = winnr()
-    call nerdtree#exec('tabdo windo if winbufnr(0) == ' . a:bufNum . " | exec ':e! " . editStr . "' | endif", 1)
+    call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . a:bufNum . " | exec ':e! " . editStr . "' | endif", 1)
     call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
     call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
     " 3. We don't need a previous buffer anymore
@@ -330,7 +330,7 @@ function! NERDTreeCopyNode()
     let prompt = s:inputPrompt('copy')
     let newNodePath = input(prompt, currentNode.path.str(), 'file')
 
-    if newNodePath != ''
+    if newNodePath !=# ''
         "strip trailing slash
         let newNodePath = substitute(newNodePath, '\/$', '', '')
 
@@ -369,7 +369,7 @@ endfunction
 function! NERDTreeCopyPath()
     let l:nodePath = g:NERDTreeFileNode.GetSelected().path.str()
     if has('clipboard')
-        if &clipboard == 'unnamedplus'
+        if &clipboard ==# 'unnamedplus'
             let @+ = l:nodePath
         else
             let @* = l:nodePath
@@ -383,7 +383,7 @@ endfunction
 " FUNCTION: NERDTreeQuickLook() {{{1
 function! NERDTreeQuickLook()
     let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode != {}
+    if treenode !=# {}
         call system("qlmanage -p 2>/dev/null '" . treenode.path.str() . "'")
     endif
 endfunction
@@ -391,7 +391,7 @@ endfunction
 " FUNCTION: NERDTreeRevealInFinder() {{{1
 function! NERDTreeRevealInFinder()
     let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode != {}
+    if treenode !=# {}
         call system("open -R '" . treenode.path.str() . "'")
     endif
 endfunction
@@ -399,7 +399,7 @@ endfunction
 " FUNCTION: NERDTreeExecuteFile() {{{1
 function! NERDTreeExecuteFile()
     let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode != {}
+    if treenode !=# {}
         call system("open '" . treenode.path.str() . "'")
     endif
 endfunction
@@ -408,7 +408,7 @@ endfunction
 function! NERDTreeRevealFileLinux()
     let treenode = g:NERDTreeFileNode.GetSelected()
     let parentnode = treenode.parent
-    if parentnode != {}
+    if parentnode !=# {}
         call system("xdg-open '" . parentnode.path.str() . "' &")
     endif
 endfunction
@@ -416,7 +416,7 @@ endfunction
 " FUNCTION: NERDTreeExecuteFileLinux() {{{1
 function! NERDTreeExecuteFileLinux()
     let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode != {}
+    if treenode !=# {}
         call system("xdg-open '" . treenode.path.str() . "' &")
     endif
 endfunction

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -34,7 +34,7 @@ endfunction
 function! s:FindParentVCSRoot(path)
     let l:path = a:path
     while !empty(l:path) &&
-        \ l:path._str() !~ '^\(\a:\\\|\/\)$' &&
+        \ l:path._str() !~# '^\(\a:\\\|\/\)$' &&
         \ !isdirectory(l:path._str() . '/.git') &&
         \ !isdirectory(l:path._str() . '/.svn') &&
         \ !isdirectory(l:path._str() . '/.hg') &&
@@ -42,6 +42,6 @@ function! s:FindParentVCSRoot(path)
         \ !isdirectory(l:path._str() . '/_darcs')
         let l:path = l:path.getParent()
     endwhile
-    return (empty(l:path) || l:path._str() =~ '^\(\a:\\\|\/\)$') ? a:path : l:path
+    return (empty(l:path) || l:path._str() =~# '^\(\a:\\\|\/\)$') ? a:path : l:path
 endfunction
 

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -17,7 +17,7 @@ command! -n=? -complete=dir -bar NERDTreeToggleVCS :call <SID>ToggleTabTreeVCS('
 function! s:CreateTabTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)
     let l:path = s:FindParentVCSRoot(l:path)
-    call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
+    call g:NERDTreeCreator.createTabTree(empty(l:path) ? '' : l:path._str())
 endfunction
 
 " FUNCTION: s:ToggleTabTreeVCS(a:name) {{{1
@@ -25,7 +25,7 @@ endfunction
 function! s:ToggleTabTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)
     let l:path = s:FindParentVCSRoot(l:path)
-    call g:NERDTreeCreator.toggleTabTree(empty(l:path) ? "" : l:path._str())
+    call g:NERDTreeCreator.toggleTabTree(empty(l:path) ? '' : l:path._str())
 endfunction
 
 " FUNCTION: s:FindParentVCSRoot(a:path) {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -11,6 +11,8 @@
 "
 " SECTION: Script init stuff {{{1
 "============================================================
+scriptencoding utf-8
+
 if exists('loaded_nerd_tree')
     finish
 endif

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -22,9 +22,9 @@ if v:version < 703
 endif
 let loaded_nerd_tree = 1
 
-"for line continuation - i.e dont want C in &cpo
-let s:old_cpo = &cpo
-set cpo&vim
+"for line continuation - i.e dont want C in &cpoptions
+let s:old_cpo = &cpoptions
+set cpoptions&vim
 
 "Function: s:initVariable() function {{{2
 "This function is used to initialise a given variable to a given value. The
@@ -255,7 +255,7 @@ endfunction
 " SECTION: Post Source Actions {{{1
 call nerdtree#postSourceActions()
 
-"reset &cpo back to users setting
-let &cpo = s:old_cpo
+"reset &cpoptions back to users setting
+let &cpoptions = s:old_cpo
 
 " vim: set sw=4 sts=4 et fdm=marker:

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -11,7 +11,7 @@
 "
 " SECTION: Script init stuff {{{1
 "============================================================
-if exists("loaded_nerd_tree")
+if exists('loaded_nerd_tree')
     finish
 endif
 if v:version < 703
@@ -36,65 +36,65 @@ set cpo&vim
 "1 if the var is set, 0 otherwise
 function! s:initVariable(var, value)
     if !exists(a:var)
-        exec 'let ' . a:var . ' = ' . "'" . substitute(a:value, "'", "''", "g") . "'"
+        exec 'let ' . a:var . ' = ' . "'" . substitute(a:value, "'", "''", 'g') . "'"
         return 1
     endif
     return 0
 endfunction
 
 "SECTION: Init variable calls and other random constants {{{2
-call s:initVariable("g:NERDTreeAutoCenter", 1)
-call s:initVariable("g:NERDTreeAutoCenterThreshold", 3)
-call s:initVariable("g:NERDTreeCaseSensitiveSort", 0)
-call s:initVariable("g:NERDTreeNaturalSort", 0)
-call s:initVariable("g:NERDTreeSortHiddenFirst", 1)
-call s:initVariable("g:NERDTreeUseTCD", 0)
-call s:initVariable("g:NERDTreeChDirMode", 0)
-call s:initVariable("g:NERDTreeCreatePrefix", "silent")
-call s:initVariable("g:NERDTreeMinimalUI", 0)
-call s:initVariable("g:NERDTreeMinimalMenu", 0)
-if !exists("g:NERDTreeIgnore")
+call s:initVariable('g:NERDTreeAutoCenter', 1)
+call s:initVariable('g:NERDTreeAutoCenterThreshold', 3)
+call s:initVariable('g:NERDTreeCaseSensitiveSort', 0)
+call s:initVariable('g:NERDTreeNaturalSort', 0)
+call s:initVariable('g:NERDTreeSortHiddenFirst', 1)
+call s:initVariable('g:NERDTreeUseTCD', 0)
+call s:initVariable('g:NERDTreeChDirMode', 0)
+call s:initVariable('g:NERDTreeCreatePrefix', 'silent')
+call s:initVariable('g:NERDTreeMinimalUI', 0)
+call s:initVariable('g:NERDTreeMinimalMenu', 0)
+if !exists('g:NERDTreeIgnore')
     let g:NERDTreeIgnore = ['\~$']
 endif
-call s:initVariable("g:NERDTreeBookmarksFile", expand('$HOME') . '/.NERDTreeBookmarks')
-call s:initVariable("g:NERDTreeBookmarksSort", 1)
-call s:initVariable("g:NERDTreeHighlightCursorline", 1)
-call s:initVariable("g:NERDTreeHijackNetrw", 1)
+call s:initVariable('g:NERDTreeBookmarksFile', expand('$HOME') . '/.NERDTreeBookmarks')
+call s:initVariable('g:NERDTreeBookmarksSort', 1)
+call s:initVariable('g:NERDTreeHighlightCursorline', 1)
+call s:initVariable('g:NERDTreeHijackNetrw', 1)
 call s:initVariable('g:NERDTreeMarkBookmarks', 1)
-call s:initVariable("g:NERDTreeMouseMode", 1)
-call s:initVariable("g:NERDTreeNotificationThreshold", 100)
-call s:initVariable("g:NERDTreeQuitOnOpen", 0)
-call s:initVariable("g:NERDTreeRespectWildIgnore", 0)
-call s:initVariable("g:NERDTreeShowBookmarks", 0)
-call s:initVariable("g:NERDTreeShowFiles", 1)
-call s:initVariable("g:NERDTreeShowHidden", 0)
-call s:initVariable("g:NERDTreeShowLineNumbers", 0)
-call s:initVariable("g:NERDTreeSortDirs", 1)
+call s:initVariable('g:NERDTreeMouseMode', 1)
+call s:initVariable('g:NERDTreeNotificationThreshold', 100)
+call s:initVariable('g:NERDTreeQuitOnOpen', 0)
+call s:initVariable('g:NERDTreeRespectWildIgnore', 0)
+call s:initVariable('g:NERDTreeShowBookmarks', 0)
+call s:initVariable('g:NERDTreeShowFiles', 1)
+call s:initVariable('g:NERDTreeShowHidden', 0)
+call s:initVariable('g:NERDTreeShowLineNumbers', 0)
+call s:initVariable('g:NERDTreeSortDirs', 1)
 
 if !nerdtree#runningWindows() && !nerdtree#runningCygwin()
-    call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
-    call s:initVariable("g:NERDTreeDirArrowCollapsible", "▾")
+    call s:initVariable('g:NERDTreeDirArrowExpandable', '▸')
+    call s:initVariable('g:NERDTreeDirArrowCollapsible', '▾')
 else
-    call s:initVariable("g:NERDTreeDirArrowExpandable", "+")
-    call s:initVariable("g:NERDTreeDirArrowCollapsible", "~")
+    call s:initVariable('g:NERDTreeDirArrowExpandable', '+')
+    call s:initVariable('g:NERDTreeDirArrowCollapsible', '~')
 endif
 
-call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
-call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
+call s:initVariable('g:NERDTreeCascadeOpenSingleChildDir', 1)
+call s:initVariable('g:NERDTreeCascadeSingleChildDir', 1)
 
-if !exists("g:NERDTreeSortOrder")
+if !exists('g:NERDTreeSortOrder')
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 endif
 let g:NERDTreeOldSortOrder = []
 
-call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
+call s:initVariable('g:NERDTreeGlyphReadOnly', 'RO')
 
-if has("conceal")
-    call s:initVariable("g:NERDTreeNodeDelimiter", "\x07")
+if has('conceal')
+    call s:initVariable('g:NERDTreeNodeDelimiter', "\x07")
 elseif (g:NERDTreeDirArrowExpandable == "\u00a0" || g:NERDTreeDirArrowCollapsible == "\u00a0")
-    call s:initVariable("g:NERDTreeNodeDelimiter", "\u00b7")
+    call s:initVariable('g:NERDTreeNodeDelimiter', "\u00b7")
 else
-    call s:initVariable("g:NERDTreeNodeDelimiter", "\u00a0")
+    call s:initVariable('g:NERDTreeNodeDelimiter', "\u00a0")
 endif
 
 if !exists('g:NERDTreeStatusline')
@@ -105,60 +105,60 @@ if !exists('g:NERDTreeStatusline')
     let g:NERDTreeStatusline = "%{exists('b:NERDTree')?b:NERDTree.root.path.str():''}"
 
 endif
-call s:initVariable("g:NERDTreeWinPos", "left")
-call s:initVariable("g:NERDTreeWinSize", 31)
+call s:initVariable('g:NERDTreeWinPos', 'left')
+call s:initVariable('g:NERDTreeWinSize', 31)
 
 "init the shell commands that will be used to copy nodes, and remove dir trees
 "
 "Note: the space after the command is important
 if nerdtree#runningWindows()
-    call s:initVariable("g:NERDTreeRemoveDirCmd", 'rmdir /s /q ')
-    call s:initVariable("g:NERDTreeCopyDirCmd", 'xcopy /s /e /i /y /q ')
-    call s:initVariable("g:NERDTreeCopyFileCmd", 'copy /y ')
+    call s:initVariable('g:NERDTreeRemoveDirCmd', 'rmdir /s /q ')
+    call s:initVariable('g:NERDTreeCopyDirCmd', 'xcopy /s /e /i /y /q ')
+    call s:initVariable('g:NERDTreeCopyFileCmd', 'copy /y ')
 else
-    call s:initVariable("g:NERDTreeRemoveDirCmd", 'rm -rf ')
-    call s:initVariable("g:NERDTreeCopyCmd", 'cp -r ')
+    call s:initVariable('g:NERDTreeRemoveDirCmd', 'rm -rf ')
+    call s:initVariable('g:NERDTreeCopyCmd', 'cp -r ')
 endif
 
 
 "SECTION: Init variable calls for key mappings {{{2
-call s:initVariable("g:NERDTreeMapCustomOpen", "<CR>")
-call s:initVariable("g:NERDTreeMapActivateNode", "o")
-call s:initVariable("g:NERDTreeMapChangeRoot", "C")
-call s:initVariable("g:NERDTreeMapChdir", "cd")
-call s:initVariable("g:NERDTreeMapCloseChildren", "X")
-call s:initVariable("g:NERDTreeMapCloseDir", "x")
-call s:initVariable("g:NERDTreeMapDeleteBookmark", "D")
-call s:initVariable("g:NERDTreeMapMenu", "m")
-call s:initVariable("g:NERDTreeMapHelp", "?")
-call s:initVariable("g:NERDTreeMapJumpFirstChild", "K")
-call s:initVariable("g:NERDTreeMapJumpLastChild", "J")
-call s:initVariable("g:NERDTreeMapJumpNextSibling", "<C-j>")
-call s:initVariable("g:NERDTreeMapJumpParent", "p")
-call s:initVariable("g:NERDTreeMapJumpPrevSibling", "<C-k>")
-call s:initVariable("g:NERDTreeMapJumpRoot", "P")
-call s:initVariable("g:NERDTreeMapOpenExpl", "e")
-call s:initVariable("g:NERDTreeMapOpenInTab", "t")
-call s:initVariable("g:NERDTreeMapOpenInTabSilent", "T")
-call s:initVariable("g:NERDTreeMapOpenRecursively", "O")
-call s:initVariable("g:NERDTreeMapOpenSplit", "i")
-call s:initVariable("g:NERDTreeMapOpenVSplit", "s")
-call s:initVariable("g:NERDTreeMapPreview", "g" . NERDTreeMapActivateNode)
-call s:initVariable("g:NERDTreeMapPreviewSplit", "g" . NERDTreeMapOpenSplit)
-call s:initVariable("g:NERDTreeMapPreviewVSplit", "g" . NERDTreeMapOpenVSplit)
-call s:initVariable("g:NERDTreeMapQuit", "q")
-call s:initVariable("g:NERDTreeMapRefresh", "r")
-call s:initVariable("g:NERDTreeMapRefreshRoot", "R")
-call s:initVariable("g:NERDTreeMapToggleBookmarks", "B")
-call s:initVariable("g:NERDTreeMapToggleFiles", "F")
-call s:initVariable("g:NERDTreeMapToggleFilters", "f")
-call s:initVariable("g:NERDTreeMapToggleHidden", "I")
-call s:initVariable("g:NERDTreeMapToggleZoom", "A")
-call s:initVariable("g:NERDTreeMapUpdir", "u")
-call s:initVariable("g:NERDTreeMapUpdirKeepOpen", "U")
-call s:initVariable("g:NERDTreeMapCWD", "CD")
-call s:initVariable("g:NERDTreeMenuDown", "j")
-call s:initVariable("g:NERDTreeMenuUp", "k")
+call s:initVariable('g:NERDTreeMapCustomOpen', '<CR>')
+call s:initVariable('g:NERDTreeMapActivateNode', 'o')
+call s:initVariable('g:NERDTreeMapChangeRoot', 'C')
+call s:initVariable('g:NERDTreeMapChdir', 'cd')
+call s:initVariable('g:NERDTreeMapCloseChildren', 'X')
+call s:initVariable('g:NERDTreeMapCloseDir', 'x')
+call s:initVariable('g:NERDTreeMapDeleteBookmark', 'D')
+call s:initVariable('g:NERDTreeMapMenu', 'm')
+call s:initVariable('g:NERDTreeMapHelp', '?')
+call s:initVariable('g:NERDTreeMapJumpFirstChild', 'K')
+call s:initVariable('g:NERDTreeMapJumpLastChild', 'J')
+call s:initVariable('g:NERDTreeMapJumpNextSibling', '<C-j>')
+call s:initVariable('g:NERDTreeMapJumpParent', 'p')
+call s:initVariable('g:NERDTreeMapJumpPrevSibling', '<C-k>')
+call s:initVariable('g:NERDTreeMapJumpRoot', 'P')
+call s:initVariable('g:NERDTreeMapOpenExpl', 'e')
+call s:initVariable('g:NERDTreeMapOpenInTab', 't')
+call s:initVariable('g:NERDTreeMapOpenInTabSilent', 'T')
+call s:initVariable('g:NERDTreeMapOpenRecursively', 'O')
+call s:initVariable('g:NERDTreeMapOpenSplit', 'i')
+call s:initVariable('g:NERDTreeMapOpenVSplit', 's')
+call s:initVariable('g:NERDTreeMapPreview', 'g' . NERDTreeMapActivateNode)
+call s:initVariable('g:NERDTreeMapPreviewSplit', 'g' . NERDTreeMapOpenSplit)
+call s:initVariable('g:NERDTreeMapPreviewVSplit', 'g' . NERDTreeMapOpenVSplit)
+call s:initVariable('g:NERDTreeMapQuit', 'q')
+call s:initVariable('g:NERDTreeMapRefresh', 'r')
+call s:initVariable('g:NERDTreeMapRefreshRoot', 'R')
+call s:initVariable('g:NERDTreeMapToggleBookmarks', 'B')
+call s:initVariable('g:NERDTreeMapToggleFiles', 'F')
+call s:initVariable('g:NERDTreeMapToggleFilters', 'f')
+call s:initVariable('g:NERDTreeMapToggleHidden', 'I')
+call s:initVariable('g:NERDTreeMapToggleZoom', 'A')
+call s:initVariable('g:NERDTreeMapUpdir', 'u')
+call s:initVariable('g:NERDTreeMapUpdirKeepOpen', 'U')
+call s:initVariable('g:NERDTreeMapCWD', 'CD')
+call s:initVariable('g:NERDTreeMenuDown', 'j')
+call s:initVariable('g:NERDTreeMenuUp', 'k')
 
 "SECTION: Load class files{{{2
 call nerdtree#loadClassFiles()
@@ -171,16 +171,16 @@ call nerdtree#ui_glue#setupCommands()
 "============================================================
 augroup NERDTree
     "Save the cursor position whenever we close the nerd tree
-    exec "autocmd BufLeave,WinLeave ". g:NERDTreeCreator.BufNamePrefix() ."* if g:NERDTree.IsOpen() | call b:NERDTree.ui.saveScreenState() | endif"
+    exec 'autocmd BufLeave,WinLeave '. g:NERDTreeCreator.BufNamePrefix() .'* if g:NERDTree.IsOpen() | call b:NERDTree.ui.saveScreenState() | endif'
 
     "disallow insert mode in the NERDTree
-    exec "autocmd BufEnter,WinEnter ". g:NERDTreeCreator.BufNamePrefix() ."* stopinsert"
+    exec 'autocmd BufEnter,WinEnter '. g:NERDTreeCreator.BufNamePrefix() .'* stopinsert'
 augroup END
 
 if g:NERDTreeHijackNetrw
     augroup NERDTreeHijackNetrw
         autocmd VimEnter * silent! autocmd! FileExplorer
-        au BufEnter,VimEnter * call nerdtree#checkForBrowse(expand("<amatch>"))
+        au BufEnter,VimEnter * call nerdtree#checkForBrowse(expand('<amatch>'))
     augroup END
 endif
 
@@ -217,7 +217,7 @@ function! NERDTreeFocus()
     if g:NERDTree.IsOpen()
         call g:NERDTree.CursorToTreeWin()
     else
-        call g:NERDTreeCreator.ToggleTabTree("")
+        call g:NERDTreeCreator.ToggleTabTree('')
     endif
 endfunction
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -91,7 +91,7 @@ call s:initVariable('g:NERDTreeGlyphReadOnly', 'RO')
 
 if has('conceal')
     call s:initVariable('g:NERDTreeNodeDelimiter', "\x07")
-elseif (g:NERDTreeDirArrowExpandable == "\u00a0" || g:NERDTreeDirArrowCollapsible == "\u00a0")
+elseif (g:NERDTreeDirArrowExpandable ==# "\u00a0" || g:NERDTreeDirArrowCollapsible ==# "\u00a0")
     call s:initVariable('g:NERDTreeNodeDelimiter', "\u00b7")
 else
     call s:initVariable('g:NERDTreeNodeDelimiter', "\u00a0")
@@ -184,7 +184,7 @@ if g:NERDTreeHijackNetrw
     augroup END
 endif
 
-if g:NERDTreeChDirMode == 3
+if g:NERDTreeChDirMode ==# 3
     augroup NERDTreeChDirOnTabSwitch
         autocmd TabEnter * if g:NERDTree.ExistsForTab()|call g:NERDTree.ForCurrentTab().getRoot().path.changeToDir()|endif
     augroup END

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -27,7 +27,7 @@ exec 'syn match NERDTreeOpenable #' . escape(g:NERDTreeDirArrowExpandable, '~') 
 
 let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~]\-').escape(g:NERDTreeDirArrowExpandable, '~]\-')
 exec 'syn match NERDTreeDir #[^'.s:dirArrows.' ].*/#'
-syn match NERDTreeExecFile  #^ .*\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmark
+syn match NERDTreeExecFile  '^ .*\*\($\| \)' contains=NERDTreeRO,NERDTreeBookmark
 exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
 
 "highlighting for readonly files

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -3,7 +3,7 @@ syn match NERDTreeIgnore #\~#
 exec 'syn match NERDTreeIgnore #\['.g:NERDTreeGlyphReadOnly.'\]#'
 
 "highlighting for the .. (up dir) line at the top of the tree
-execute "syn match NERDTreeUp #\\V". s:tree_up_dir_line ."#"
+execute "syn match NERDTreeUp #\\V". s:tree_up_dir_line .'#'
 
 "quickhelp syntax elements
 syn match NERDTreeHelpKey #" \{1,2\}[^ ]*:#ms=s+2,me=e-1
@@ -37,7 +37,7 @@ syn match NERDTreeFlags #^ *\zs\[[^\]]*\]# containedin=NERDTreeFile,NERDTreeExec
 syn match NERDTreeFlags #\[[^\]]*\]# containedin=NERDTreeDir
 
 "highlighing to conceal the delimiter around the file/dir name
-if has("conceal")
+if has('conceal')
     exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# conceal containedin=ALL'
     setlocal conceallevel=3 concealcursor=nvic
 else


### PR DESCRIPTION
Linting is not as good as full on integration testing, but this is a start. The [vint linter](https://github.com/Kuniwak/vint) for VimL is actually pretty good. It's noisy the first time you run it because it's picking about idiosyncrasies of VIM's language and wants all code to avoid even potential breakage, but it is all good practice and once everything is fixed it's pretty easy to use. Once installed it can be run locally using `vint .` from the project root.

The CI job included here will run the linter in Github Actions and a bot will leave comments on PRs on the line of code where any lint issues are found.

There are a couple flat out bugs that it caught, but most of the changes here were just fixing warnings. I highly recommend this PR ***not* be squashed**! This touches a TON of code, but each commit is split out by the kind of lint issue being fixed and it will be much easier to understand the `git blame` output and potentially `git bisect` if a problem was introduced if they are **not** lumped together.

Please do make sure the plugin still runs as expected. I don't usually use it myself so I'm not a good one to put it through even quick paces.

If you poor through the diff it's probably a good idea to do so a commit at a time so it's not just a mess of changes ;-)

After it is merged I would recommend setting `master` up as a protected branch and requiring the CI job to pass on all PRs before merger. I can set that up in the Github settings is you approve (but I wont' mess with it unless you give the word).