### PR TITLE
[BUGFIX] Shows error for empty filenames (vim-startify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.4
+- **.6:** NERDTreeFind shows expected message if file doesn't exist e.g. with vim-startify (andys8). [#1081](https://github.com/preservim/nerdtree/pull/1081)
 - **.5**: Ensure events are (or aren't) being ignored correctly. (PhilRunninger) [#1080](https://github.com/preservim/nerdtree/pull/1080)
 - **.4**: Prevent overwriting existing files/dirs on node move. (PhilRunninger) [#1079](https://github.com/preservim/nerdtree/pull/1079)
 - **.3**: Fix regex that finds keyword for minimal menu. (PhilRunninger) [#1075](https://github.com/preservim/nerdtree/pull/1075)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -284,13 +284,14 @@ endfunction
 " FUNCTION: s:findAndRevealPath(pathStr) {{{1
 function! s:findAndRevealPath(pathStr) abort
     let l:pathStr = !empty(a:pathStr) ? a:pathStr : expand('%:p')
-    if !filereadable(l:pathStr)
-        let l:pathStr = fnamemodify(l:pathStr, ':h')
-    endif
 
     if empty(l:pathStr)
         call nerdtree#echoWarning('no file for the current buffer')
         return
+    endif
+
+    if !filereadable(l:pathStr)
+        let l:pathStr = fnamemodify(l:pathStr, ':h')
     endif
 
     try


### PR DESCRIPTION
### Description of Changes

There was a fix in #1043 which improves the behavior for non saved filenames. Those are not on disk, but also not empty. This lead to an issue #1059 where actual "empty files" like created with vim-startify or stdin lead to an error. This change fixes this by adapting the order of the tests. It'll print "no file for the current buffer" for empty files.

Closes #1059


