### PR TITLE
NERDTree <start-directory> always sets NERDTree root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.5
-- **.0**: `NERDTreeToggle <start-directory>` always sets NERDTree root. (PhilRunninger) [#1082](https://github.com/preservim/nerdtree/pull/1082)
+- **.0**: `NERDTreeToggle <start-directory>` always sets NERDTree root. (PhilRunninger) [#1083](https://github.com/preservim/nerdtree/pull/1083)
 #### 6.4
 - **.6**: NERDTreeFind shows expected message if file doesn't exist e.g. with vim-startify (andys8). [#1081](https://github.com/preservim/nerdtree/pull/1081)
 - **.5**: Ensure events are (or aren't) being ignored correctly. (PhilRunninger) [#1080](https://github.com/preservim/nerdtree/pull/1080)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.5
+- **.0**: `NERDTreeToggle <start-directory>` always sets NERDTree root. (PhilRunninger) [#1082](https://github.com/preservim/nerdtree/pull/1082)
 #### 6.4
 - **.6**: NERDTreeFind shows expected message if file doesn't exist e.g. with vim-startify (andys8). [#1081](https://github.com/preservim/nerdtree/pull/1081)
 - **.5**: Ensure events are (or aren't) being ignored correctly. (PhilRunninger) [#1080](https://github.com/preservim/nerdtree/pull/1080)

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -122,8 +122,9 @@ The following features and functionality are provided by the NERDTree:
 
 :NERDTreeToggle [<start-directory> | <bookmark>]               *:NERDTreeToggle*
     If a NERDTree already exists for this tab, it is reopened and rendered
-    again.  If no NERDTree exists for this tab then this command acts the
-    same as the |:NERDTree| command.
+    again. If <start-directory> or <bookmark> is given, the root of NERDTree
+    is set to that path. If no NERDTree exists for this tab then this command
+    acts the same as the |:NERDTree| command.
 
 :NERDTreeToggleVCS [<start-directory> | <bookmark>]            *:NERDTreeToggleVCS*
     Like |:NERDTreeToggle|, but searches up the directory tree to find the top of

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -355,17 +355,20 @@ function! s:Creator.ToggleTabTree(dir)
 endfunction
 
 " FUNCTION: s:Creator.toggleTabTree(dir) {{{1
-" Toggles the NERD tree. I.e the NERD tree is open, it is closed, if it is
-" closed it is restored or initialized (if it doesnt exist)
+" Toggles the NERD tree. I.e if the NERD tree is open, it is closed. If it is
+" closed, it is restored or initialized. If dir is not empty, it will be set
+" as the new root.
 "
 " Args:
-" dir: the full path for the root node (is only used if the NERD tree is being
-" initialized.
+" dir: the full path for the root node (is used if the NERD tree is being
+" initialized, or to change the root to a new dir.)
 function! s:Creator.toggleTabTree(dir)
     if g:NERDTree.ExistsForTab()
         if !g:NERDTree.IsOpen()
             call self._createTreeWin()
-            if !&hidden
+            if !empty(a:dir)
+                call self.createTabTree(a:dir)
+            elseif !&hidden
                 call b:NERDTree.render()
             endif
             call b:NERDTree.ui.restoreScreenState()


### PR DESCRIPTION
### Description of Changes
Closes #1076  <!-- Issue number this PR addresses. If none, remove this line. -->


---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
