### PR TITLE
Add the ability to turn off directory arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # NERDTree Change Log
-
-<!--
-    Introduce a new MAJOR.MINOR version with a 4-hash header.
-
-    PATCH versions are listed from newest to oldest under their respective MAJOR.MINOR version
-    in an unordered list.  The format is:
+<!-- Introduce a new MAJOR or MINOR version with a 4-hash header.
+     PATCH versions are listed from newest to oldest under their respective MAJOR.MINOR
+     version in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.6
+- **.0**: Add the ability to turn off directory arrows (PhilRunninger) [#1085](https://github.com/preservim/nerdtree/pull/1085)
 #### 6.5
 - **.0**: `NERDTreeToggle <start-directory>` always sets NERDTree root. (PhilRunninger) [#1083](https://github.com/preservim/nerdtree/pull/1083)
 #### 6.4

--- a/README.markdown
+++ b/README.markdown
@@ -143,3 +143,8 @@ Use these variables in your vimrc. Note that below are default arrow symbols
 let g:NERDTreeDirArrowExpandable = '▸'
 let g:NERDTreeDirArrowCollapsible = '▾'
 ```
+You can remove the arrows altogether by setting these variables to empty strings, as shown below. This will remove not only the arrows, but a single space following them, shifting the whole tree two character positions to the left.
+```vim
+let g:NERDTreeDirArrowExpandable = ''
+let g:NERDTreeDirArrowCollapsible = ''
+```

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1223,13 +1223,19 @@ Values: Any single character.
 Defaults:   Windows: ~ and +    Others: ▾ and ▸
 
 These characters indicate whether a directory is collapsible or expandable.
-
-They can be set to "\u00a0" to hide the arrows, but if you do this you may
-need to change the node delimiter. See |NERDTreeNodeDelimiter|. You cannot use
-the same character for both the arrows and the delimiter. Example: >
+Example: >
     let NERDTreeDirArrowExpandable=">"
     let NERDTreeDirArrowCollapsible="v"
 <
+They can be set to "\u00a0" to replace the arrows with a non-breaking space.
+If you do this you may need to change the node delimiter. See
+|NERDTreeNodeDelimiter|. You cannot use the same character for both the arrows
+and the delimiter.
+
+Alternatively, they can be set to '' (an empty string). This removes the
+arrows and the single space that follows them, shifting the entire tree two
+character positions to the left.
+
 ------------------------------------------------------------------------------
                                                          *NERDTreeNodeDelimiter*
 Values: Any single character.

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -104,8 +104,8 @@ function! s:TreeDirNode.displayString()
     endfor
 
     " Select the appropriate open/closed status indicator symbol.
-    let l:padding = g:NERDTreeDirArrowExpandable ==# '' ? '' : ' '
-    let l:symbol = (l:cascade[-1].isOpen ? g:NERDTreeDirArrowCollapsible : g:NERDTreeDirArrowExpandable ) . l:padding
+    let l:symbol = (l:cascade[-1].isOpen ? g:NERDTreeDirArrowCollapsible : g:NERDTreeDirArrowExpandable )
+    let l:symbol .= (g:NERDTreeDirArrowExpandable ==# '' ? '' : ' ')
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 
     return l:symbol . l:flags . l:label

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -104,7 +104,7 @@ function! s:TreeDirNode.displayString()
     endfor
 
     " Select the appropriate open/closed status indicator symbol.
-    let l:padding = g:NERDTreeDirArrowExpandable == '' ? '' : ' '
+    let l:padding = g:NERDTreeDirArrowExpandable ==# '' ? '' : ' '
     let l:symbol = (l:cascade[-1].isOpen ? g:NERDTreeDirArrowCollapsible : g:NERDTreeDirArrowExpandable ) . l:padding
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -104,16 +104,11 @@ function! s:TreeDirNode.displayString()
     endfor
 
     " Select the appropriate open/closed status indicator symbol.
-    if l:cascade[-1].isOpen
-        let l:symbol = g:NERDTreeDirArrowCollapsible
-    else
-        let l:symbol = g:NERDTreeDirArrowExpandable
-    endif
-
+    let l:padding = g:NERDTreeDirArrowExpandable == '' ? '' : ' '
+    let l:symbol = (l:cascade[-1].isOpen ? g:NERDTreeDirArrowCollapsible : g:NERDTreeDirArrowExpandable ) . l:padding
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 
-    let l:result = l:symbol . ' ' . l:flags . l:label
-    return l:result
+    return l:symbol . l:flags . l:label
 endfunction
 
 " FUNCTION: TreeDirNode.findNode(path) {{{1

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -321,13 +321,11 @@ function! s:TreeFileNode._renderToString(depth, drawText)
     if a:drawText ==# 1
 
         let treeParts = repeat('  ', a:depth - 1)
-
-        if !self.path.isDirectory
-            let treeParts = treeParts . '  '
+        if !self.path.isDirectory && g:NERDTreeDirArrowExpandable != ''
+            let treeParts .= '  '
         endif
 
         let line = treeParts . self.displayString()
-
         let output = output . line . "\n"
     endif
 

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -321,7 +321,7 @@ function! s:TreeFileNode._renderToString(depth, drawText)
     if a:drawText ==# 1
 
         let treeParts = repeat('  ', a:depth - 1)
-        if !self.path.isDirectory && g:NERDTreeDirArrowExpandable != ''
+        if !self.path.isDirectory && g:NERDTreeDirArrowExpandable !=# ''
             let treeParts .= '  '
         endif
 

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -321,9 +321,7 @@ function! s:TreeFileNode._renderToString(depth, drawText)
     if a:drawText ==# 1
 
         let treeParts = repeat('  ', a:depth - 1)
-        if !self.path.isDirectory && g:NERDTreeDirArrowExpandable !=# ''
-            let treeParts .= '  '
-        endif
+        let treeParts .= (self.path.isDirectory || g:NERDTreeDirArrowExpandable ==# '' ? '' : '  ')
 
         let line = treeParts . self.displayString()
         let output = output . line . "\n"

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -284,7 +284,11 @@ endfunction
 function! s:UI._indentLevelFor(line)
     " Replace multi-character DirArrows with a single space so the
     " indentation calculation doesn't get messed up.
-    let l:line = substitute(substitute(a:line, '\V'.g:NERDTreeDirArrowExpandable, ' ', ''), '\V'.g:NERDTreeDirArrowCollapsible, ' ', '')
+    if g:NERDTreeDirArrowExpandable ==# ''
+        let l:line = '  '.a:line
+    else
+        let l:line = substitute(substitute(a:line, '\V'.g:NERDTreeDirArrowExpandable, ' ', ''), '\V'.g:NERDTreeDirArrowCollapsible, ' ', '')
+    endif
     let leadChars = match(l:line, '\M\[^ ]')
     return leadChars / s:UI.IndentWid()
 endfunction

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -22,7 +22,7 @@ syn match NERDTreeLinkDir #.*/ ->#me=e-3 containedin=NERDTreeDir
 "highlighing for directory nodes and file nodes
 syn match NERDTreeDirSlash #/# containedin=NERDTreeDir
 
-if g:NERDTreeDirArrowExpandable != ''
+if g:NERDTreeDirArrowExpandable !=# ''
     exec 'syn match NERDTreeClosable #' . escape(g:NERDTreeDirArrowCollapsible, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
     exec 'syn match NERDTreeOpenable #' . escape(g:NERDTreeDirArrowExpandable, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
     let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~]\-').escape(g:NERDTreeDirArrowExpandable, '~]\-')

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -19,6 +19,15 @@ syn match NERDTreeLinkTarget #->.*# containedin=NERDTreeDir,NERDTreeFile
 syn match NERDTreeLinkFile #.* ->#me=e-3 containedin=NERDTreeFile
 syn match NERDTreeLinkDir #.*/ ->#me=e-3 containedin=NERDTreeDir
 
+"highlighting to conceal the delimiter around the file/dir name
+if has('conceal')
+    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# conceal containedin=ALL'
+    setlocal conceallevel=3 concealcursor=nvic
+else
+    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# containedin=ALL'
+    hi! link NERDTreeNodeDelimiters Ignore
+endif
+
 "highlighing for directory nodes and file nodes
 syn match NERDTreeDirSlash #/# containedin=NERDTreeDir
 
@@ -39,15 +48,6 @@ endif
 exec 'syn match NERDTreeRO #.*'.g:NERDTreeNodeDelimiter.'\zs.*\ze'.g:NERDTreeNodeDelimiter.'.*\['.g:NERDTreeGlyphReadOnly.'\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile'
 
 exec 'syn match NERDTreeFlags #\[[^\]]*\]\ze'.g:NERDTreeNodeDelimiter.'# containedin=NERDTreeFile,NERDTreeExecFile,NERDTreeDir'
-
-"highlighing to conceal the delimiter around the file/dir name
-if has('conceal')
-    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# conceal containedin=ALL'
-    setlocal conceallevel=3 concealcursor=nvic
-else
-    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# containedin=ALL'
-    hi! link NERDTreeNodeDelimiters Ignore
-endif
 
 syn match NERDTreeCWD #^[</].*$#
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -31,8 +31,8 @@ if g:NERDTreeDirArrowExpandable !=# ''
     exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
 else
     exec 'syn match NERDTreeDir #[^'.g:NERDTreeNodeDelimiter.']\{-}/\ze\($\|'.g:NERDTreeNodeDelimiter.'\)#'
-    exec 'syn match NERDTreeExecFile #'.g:NERDTreeNodeDelimiter.'.\{-}\*\($\|'.g:NERDTreeNodeDelimiter.'\)# contains=NERDTreeRO,NERDTreeBookmark'
-    exec 'syn match NERDTreeFile     #^.\{-}'.g:NERDTreeNodeDelimiter.'.\{-}[^\/]\($\|'.g:NERDTreeNodeDelimiter.'.*\)# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
+    exec 'syn match NERDTreeExecFile #[^'.g:NERDTreeNodeDelimiter.']\{-}'.g:NERDTreeNodeDelimiter.'\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmark'
+    exec 'syn match NERDTreeFile     #^.*'.g:NERDTreeNodeDelimiter.'.*[^\/]\($\|'.g:NERDTreeNodeDelimiter.'.*\)# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
 endif
 
 "highlighting for readonly files

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -22,19 +22,23 @@ syn match NERDTreeLinkDir #.*/ ->#me=e-3 containedin=NERDTreeDir
 "highlighing for directory nodes and file nodes
 syn match NERDTreeDirSlash #/# containedin=NERDTreeDir
 
-exec 'syn match NERDTreeClosable #' . escape(g:NERDTreeDirArrowCollapsible, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
-exec 'syn match NERDTreeOpenable #' . escape(g:NERDTreeDirArrowExpandable, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
-
-let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~]\-').escape(g:NERDTreeDirArrowExpandable, '~]\-')
-exec 'syn match NERDTreeDir #[^'.s:dirArrows.' ].*/#'
-syn match NERDTreeExecFile  '^ .*\*\($\| \)' contains=NERDTreeRO,NERDTreeBookmark
-exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
+if g:NERDTreeDirArrowExpandable != ''
+    exec 'syn match NERDTreeClosable #' . escape(g:NERDTreeDirArrowCollapsible, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
+    exec 'syn match NERDTreeOpenable #' . escape(g:NERDTreeDirArrowExpandable, '~') . '\ze .*/# containedin=NERDTreeDir,NERDTreeFile'
+    let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~]\-').escape(g:NERDTreeDirArrowExpandable, '~]\-')
+    exec 'syn match NERDTreeDir #[^'.s:dirArrows.' ].*/#'
+    exec 'syn match NERDTreeExecFile #^.*'.g:NERDTreeNodeDelimiter.'\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmark'
+    exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
+else
+    exec 'syn match NERDTreeDir #[^'.g:NERDTreeNodeDelimiter.']\{-}/\ze\($\|'.g:NERDTreeNodeDelimiter.'\)#'
+    exec 'syn match NERDTreeExecFile #'.g:NERDTreeNodeDelimiter.'.\{-}\*\($\|'.g:NERDTreeNodeDelimiter.'\)# contains=NERDTreeRO,NERDTreeBookmark'
+    exec 'syn match NERDTreeFile     #^.\{-}'.g:NERDTreeNodeDelimiter.'.\{-}[^\/]\($\|'.g:NERDTreeNodeDelimiter.'.*\)# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
+endif
 
 "highlighting for readonly files
-exec 'syn match NERDTreeRO # *\zs.*\ze \['.g:NERDTreeGlyphReadOnly.'\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile'
+exec 'syn match NERDTreeRO #.*'.g:NERDTreeNodeDelimiter.'\zs.*\ze'.g:NERDTreeNodeDelimiter.'.*\['.g:NERDTreeGlyphReadOnly.'\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile'
 
-syn match NERDTreeFlags #^ *\zs\[[^\]]*\]# containedin=NERDTreeFile,NERDTreeExecFile
-syn match NERDTreeFlags #\[[^\]]*\]# containedin=NERDTreeDir
+exec 'syn match NERDTreeFlags #\[[^\]]*\]\ze'.g:NERDTreeNodeDelimiter.'# containedin=NERDTreeFile,NERDTreeExecFile,NERDTreeDir'
 
 "highlighing to conceal the delimiter around the file/dir name
 if has('conceal')


### PR DESCRIPTION
### Description of Changes
Closes #1064  <!-- Issue number this PR addresses. If none, remove this line. -->

Directory arrows can now be turned off. Formerly it was possible to turn the arrows into a non-breaking space, but this is different in that the entire tree is shifted to the left two character positions by removing the arrow and the space that follows it.

---
### New Version Info
#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
