### PR TITLE
Open the parent directory when revealing a non-existent file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
      version in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.7
+- **.0**: Open the parent directory when revealing a non-existent file with :NERDTreeFind (bouk) [#1090](https://github.com/preservim/nerdtree/pull/1090)
 #### 6.6
 - **.1**: [add] How to install using dein.vim (kazukazuinaina) [#1087](https://github.com/preservim/nerdtree/pull/1087)
 - **.0**: Add the ability to turn off directory arrows (PhilRunninger) [#1085](https://github.com/preservim/nerdtree/pull/1085)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -284,6 +284,7 @@ endfunction
 " FUNCTION: s:findAndRevealPath(pathStr) {{{1
 function! s:findAndRevealPath(pathStr) abort
     let l:pathStr = !empty(a:pathStr) ? a:pathStr : expand('%:p')
+    let l:revealOpts = {}
 
     if empty(l:pathStr)
         call nerdtree#echoWarning('no file for the current buffer')
@@ -292,6 +293,7 @@ function! s:findAndRevealPath(pathStr) abort
 
     if !filereadable(l:pathStr)
         let l:pathStr = fnamemodify(l:pathStr, ':h')
+        let l:revealOpts["open"] = 1
     endif
 
     try
@@ -327,7 +329,7 @@ function! s:findAndRevealPath(pathStr) abort
         call b:NERDTree.ui.setShowHidden(1)
     endif
 
-    let l:node = b:NERDTree.root.reveal(l:pathObj)
+    let l:node = b:NERDTree.root.reveal(l:pathObj, l:revealOpts)
     call b:NERDTree.render()
     call l:node.putCursorHere(1, 0)
 endfunction

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -293,7 +293,7 @@ function! s:findAndRevealPath(pathStr) abort
 
     if !filereadable(l:pathStr)
         let l:pathStr = fnamemodify(l:pathStr, ':h')
-        let l:revealOpts["open"] = 1
+        let l:revealOpts['open'] = 1
     endif
 
     try


### PR DESCRIPTION
Right now it just reveals the directory but leaves it closed.

Related to #1043

### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.

#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
