### PR TITLE
Add missing calls to the shellescape() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
-- **.4**: Add missing calls to `shellescape()` in the `fs_menu.vim` plugin (lifecrisis) [#1099](https://github.com/preservim/nerdtree/pull/1099)
+- **.4**: Add missing calls to the `shellescape()` function (lifecrisis) [#1099](https://github.com/preservim/nerdtree/pull/1099)
 - **.3**: Fix vsplit to not open empty buffers when opening previously closed file (AwkwardKore) [#1098](https://github.com/preservim/nerdtree/pull/1098)
 - **.2**: Fix infinity loop (on winvim) in FindParentVCSRoot (Eugenij-W) [#1095](https://github.com/preservim/nerdtree/pull/1095)
 - **.1**: File Move: Escape existing directory name when looking for open files. (PhilRunninger) [#1094](https://github.com/preservim/nerdtree/pull/1094)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.4**: Add missing calls to `shellescape()` in the `fs_menu.vim` plugin (lifecrisis) [#1099](https://github.com/preservim/nerdtree/pull/1099)
 - **.3**: Fix vsplit to not open empty buffers when opening previously closed file (AwkwardKore) [#1098](https://github.com/preservim/nerdtree/pull/1098)
 - **.2**: Fix infinity loop (on winvim) in FindParentVCSRoot (Eugenij-W) [#1095](https://github.com/preservim/nerdtree/pull/1095)
 - **.1**: File Move: Escape existing directory name when looking for open files. (PhilRunninger) [#1094](https://github.com/preservim/nerdtree/pull/1094)

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -199,7 +199,7 @@ function! s:Path.copy(dest)
         let cmd_prefix = (self.isDirectory ? g:NERDTreeCopyDirCmd : g:NERDTreeCopyFileCmd)
     endif
 
-    let cmd = cmd_prefix . ' ' . escape(self.str(), self._escChars()) . ' ' . escape(a:dest, self._escChars())
+    let cmd = cmd_prefix . ' ' . shellescape(self.str()) . ' ' . shellescape(a:dest)
     let success = system(cmd)
     if v:shell_error !=# 0
         throw "NERDTree.CopyError: Could not copy '". self.str() ."' to: '" . a:dest . "'"

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -421,11 +421,13 @@ endfunction
 
 " FUNCTION: NERDTreeRevealFileLinux() {{{1
 function! NERDTreeRevealFileLinux()
-    let treenode = g:NERDTreeFileNode.GetSelected()
-    let parentnode = treenode.parent
-    if parentnode !=# {}
-        call system("xdg-open '" . parentnode.path.str() . "' &")
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node.parent)
+        return
     endif
+
+    call system('xdg-open ' . shellescape(l:node.parent.path.str()))
 endfunction
 
 " FUNCTION: NERDTreeExecuteFileLinux() {{{1

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -388,10 +388,13 @@ endfunction
 
 " FUNCTION: NERDTreeQuickLook() {{{1
 function! NERDTreeQuickLook()
-    let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode !=# {}
-        call system("qlmanage -p 2>/dev/null '" . treenode.path.str() . "'")
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node)
+        return
     endif
+
+    call system('qlmanage -p 2>/dev/null ' . shellescape(l:node.path.str()))
 endfunction
 
 " FUNCTION: NERDTreeRevealInFinder() {{{1
@@ -428,4 +431,3 @@ function! NERDTreeExecuteFileLinux()
 endfunction
 
 " vim: set sw=4 sts=4 et fdm=marker:
-

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -399,10 +399,13 @@ endfunction
 
 " FUNCTION: NERDTreeRevealInFinder() {{{1
 function! NERDTreeRevealInFinder()
-    let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode !=# {}
-        call system("open -R '" . treenode.path.str() . "'")
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node)
+        return
     endif
+
+    call system('open -R ' . shellescape(l:node.path.str()))
 endfunction
 
 " FUNCTION: NERDTreeExecuteFile() {{{1

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -423,6 +423,16 @@ endfunction
 function! NERDTreeRevealFileLinux()
     let l:node = g:NERDTreeFileNode.GetSelected()
 
+    if empty(l:node)
+        return
+    endif
+
+    " Handle the edge case of "/", which has no parent.
+    if l:node.path.str() ==# '/'
+        call system('xdg-open /')
+        return
+    endif
+
     if empty(l:node.parent)
         return
     endif

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -432,10 +432,13 @@ endfunction
 
 " FUNCTION: NERDTreeExecuteFileLinux() {{{1
 function! NERDTreeExecuteFileLinux()
-    let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode !=# {}
-        call system("xdg-open '" . treenode.path.str() . "' &")
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node)
+        return
     endif
+
+    call system('xdg-open ' . shellescape(l:node.path.str()))
 endfunction
 
 " vim: set sw=4 sts=4 et fdm=marker:

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -410,10 +410,13 @@ endfunction
 
 " FUNCTION: NERDTreeExecuteFile() {{{1
 function! NERDTreeExecuteFile()
-    let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode !=# {}
-        call system("open '" . treenode.path.str() . "'")
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node)
+        return
     endif
+
+    call system('open ' . shellescape(l:node.path.str()))
 endfunction
 
 " FUNCTION: NERDTreeRevealFileLinux() {{{1


### PR DESCRIPTION
### Description of Changes

This is a security fix for `nerdtree_plugin/fs_menu.vim` that adds several missing calls to `shellescape()` that are actually required.  It also adds missing `shellescape()` calls in two other places. This is necessary to prevent shell command injection.  

It is quite an unlikely exploit, however.

**N.B.** I suggest that other calls to `system()` throughout the NERDTree code be audited for correct usage of `shellescape()`.  Some of them seem to use a custom escaping function that may or may not be correct.  These probably should be converted to use the `shellescape()` function.

See commit messages for more details about some of the ancillary changes.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
