### PR TITLE
Prevent unneeded tree creation in :NERDTreeToggle[VCS] <path>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.5**: Prevent unneeded tree creation in :NERDTreeToggle[VCS] <path> (PhilRunninger) [#1101](https://github.com/preservim/nerdtree/pull/1101)
 - **.4**: Add missing calls to the `shellescape()` function (lifecrisis) [#1099](https://github.com/preservim/nerdtree/pull/1099)
 - **.3**: Fix vsplit to not open empty buffers when opening previously closed file (AwkwardKore) [#1098](https://github.com/preservim/nerdtree/pull/1098)
 - **.2**: Fix infinity loop (on winvim) in FindParentVCSRoot (Eugenij-W) [#1095](https://github.com/preservim/nerdtree/pull/1095)

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -366,8 +366,7 @@ function! s:Creator.toggleTabTree(dir)
     if g:NERDTree.ExistsForTab()
         if !g:NERDTree.IsOpen()
             call self._createTreeWin()
-            let l:currentPath = b:NERDTree.root.path.str()
-            if !empty(a:dir) && a:dir !=# l:currentPath
+            if !empty(a:dir) && a:dir !=# b:NERDTree.root.path.str()
                 call self.createTabTree(a:dir)
             elseif !&hidden
                 call b:NERDTree.render()

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -366,7 +366,7 @@ function! s:Creator.toggleTabTree(dir)
     if g:NERDTree.ExistsForTab()
         if !g:NERDTree.IsOpen()
             call self._createTreeWin()
-            let l:currentPath = getbufvar(t:NERDTreeBufName,'NERDTree').root.path.str()
+            let l:currentPath = b:NERDTree.root.path.str()
             if !empty(a:dir) && a:dir !=# l:currentPath
                 call self.createTabTree(a:dir)
             elseif !&hidden

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -366,7 +366,8 @@ function! s:Creator.toggleTabTree(dir)
     if g:NERDTree.ExistsForTab()
         if !g:NERDTree.IsOpen()
             call self._createTreeWin()
-            if !empty(a:dir)
+            let l:currentPath = getbufvar(t:NERDTreeBufName,"NERDTree").root.path.str()
+            if !empty(a:dir) && a:dir !=# l:currentPath
                 call self.createTabTree(a:dir)
             elseif !&hidden
                 call b:NERDTree.render()

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -366,7 +366,7 @@ function! s:Creator.toggleTabTree(dir)
     if g:NERDTree.ExistsForTab()
         if !g:NERDTree.IsOpen()
             call self._createTreeWin()
-            let l:currentPath = getbufvar(t:NERDTreeBufName,"NERDTree").root.path.str()
+            let l:currentPath = getbufvar(t:NERDTreeBufName,'NERDTree').root.path.str()
             if !empty(a:dir) && a:dir !=# l:currentPath
                 call self.createTabTree(a:dir)
             elseif !&hidden


### PR DESCRIPTION
### Description of Changes
Closes #1100   <!-- Issue number this PR addresses. If none, remove this line. -->

`NERDTreeToggleVCS` works by finding the root of the repository and passing it to the `NERDTreeToggle <path>` function. Pull request #1083 changed the way `NERDTreeToggle` works, such that when a path is specified, the NERDTree's root is always set to that path. The NERDTree is collapsed as it always is when setting a new root.

This pull request tempers that behavior. If the path given (the repo's root in this case) is the same as the current NERDTree root, then don't recreate the tree.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
