### PR TITLE
If a file's already open in the window, don't edit it again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
-- **.5**: Prevent unneeded tree creation in :NERDTreeToggle[VCS] <path> (PhilRunninger) [#1101](https://github.com/preservim/nerdtree/pull/1101)
+- **.6**: If a file's already open in the window, don't edit it again. (PhilRunninger) [#1103](https://github.com/preservim/nerdtree/pull/1103)
+- **.5**: Prevent unneeded tree creation in `:NERDTreeToggle[VCS] <path>` (PhilRunninger) [#1101](https://github.com/preservim/nerdtree/pull/1101)
 - **.4**: Add missing calls to the `shellescape()` function (lifecrisis) [#1099](https://github.com/preservim/nerdtree/pull/1099)
 - **.3**: Fix vsplit to not open empty buffers when opening previously closed file (AwkwardKore) [#1098](https://github.com/preservim/nerdtree/pull/1098)
 - **.2**: Fix infinity loop (on winvim) in FindParentVCSRoot (Eugenij-W) [#1095](https://github.com/preservim/nerdtree/pull/1095)

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -295,8 +295,9 @@ endfunction
 
 " FUNCTION: Path.edit() {{{1
 function! s:Path.edit()
-    if bufname() !=# self.str({'format': 'Edit'})
-        exec 'edit ' . self.str({'format': 'Edit'})
+    let l:bufname = self.str({'format': 'Edit'})
+    if bufname() !=# l:bufname
+        exec 'edit ' . l:bufname
     endif
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -295,7 +295,9 @@ endfunction
 
 " FUNCTION: Path.edit() {{{1
 function! s:Path.edit()
-    exec 'edit ' . self.str({'format': 'Edit'})
+    if bufname() !=# self.str({'format': 'Edit'})
+        exec 'edit ' . self.str({'format': 'Edit'})
+    endif
 endfunction
 
 " FUNCTION: Path.extractDriveLetter(fullpath) {{{1


### PR DESCRIPTION
### Description of Changes
Closes #1102   <!-- Issue number this PR addresses. If none, remove this line. -->

The issue can be recreated without NERDTree using these commands that simulate what NERDTree does:

```bash
$ echo "hello" > world.txt
$ vim
```

```vim
:set noconfirm
:e world.txt
:copy 0
:vsplit
:e world.txt
```

The solution is to skip the second `:e world.txt` command if the file is already open in the new window. This fixes a regression introduced in #1098.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
