### PR TITLE
Add an global option to choose what to put around flagstring

### DIFF
--- a/lib/nerdtree/flag_set.vim
+++ b/lib/nerdtree/flag_set.vim
@@ -52,7 +52,15 @@ function! s:FlagSet.renderToString()
         return ''
     endif
 
-    return '[' . flagstring . ']'
+    if !exists('g:NERDTreeFlagstringLeft')
+        let g:NERDTreeFlagstringLeft = '['
+    endif
+
+    if !exists('g:NERDTreeFlagstringRight')
+        let g:NERDTreeFlagstringRight = ']'
+    endif
+
+    return g:NERDTreeFlagstringLeft . flagstring . g:NERDTreeFlagstringRight
 endfunction
 
 " vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
### Description of Changes
Closes https://github.com/ryanoasis/vim-devicons/issues/278

This merge request add `g:NERDTreeFlagstringLeft` and `g:NERDTreeFlagstringRight` option for change or remove the brackets around flagstring.

It's my first contribution on a vim plugin, please do a code review to be sure there is no side effect ;)

---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
