### PR TITLE
Fix example code for the NERDTreeAddKeyMap function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.8**: Fix example code for the NERDTreeAddKeyMap function. (PhilRunninger) [#1116](https://github.com/preservim/nerdtree/pull/1116)
 - **.7**: Put '%' argument in bufname() for backwards compatibility. (PhilRunninger) [#1105](https://github.com/preservim/nerdtree/pull/1105)
 - **.6**: If a file's already open in the window, don't edit it again. (PhilRunninger) [#1103](https://github.com/preservim/nerdtree/pull/1103)
 - **.5**: Prevent unneeded tree creation in `:NERDTreeToggle[VCS] <path>` (PhilRunninger) [#1101](https://github.com/preservim/nerdtree/pull/1101)

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1353,12 +1353,12 @@ NERDTreeAddKeyMap({options})                               *NERDTreeAddKeyMap()*
     Example: >
         call NERDTreeAddKeyMap({
                \ 'key': 'foo',
-               \ 'callback': 'NERDTreeCDHandler',
+               \ 'callback': 'NERDTreeEchoPathHandler',
                \ 'quickhelpText': 'echo full path of current node',
                \ 'scope': 'DirNode' })
 
-        function! NERDTreeCDHandler(dirnode)
-            call a:dirnode.changeToDir()
+        function! NERDTreeEchoPathHandler(dirnode)
+            echo a:dirnode.path.str()
         endfunction
 <
     This code should sit in a file like ~/.vim/nerdtree_plugin/mymapping.vim.


### PR DESCRIPTION
The quickhelpText didn't match what the statement in the callback function actually did.

### Description of Changes
Closes #1114  <!-- Issue number this PR addresses. If none, remove this line. -->

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
