### PR TITLE
Do not consider the tree root to be "cascadable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.10**: Do not consider the tree root to be "cascadable". (lifecrisis) [#1120](https://github.com/preservim/nerdtree/pull/1120)
 - **.9**: Force `:NERDTreeFocus` to allow events to be fired when switching windows. (PhilRunninger) [#1118](https://github.com/preservim/nerdtree/pull/1118)
 - **.8**: Fix example code for the `NERDTreeAddKeyMap()` function. (PhilRunninger) [#1116](https://github.com/preservim/nerdtree/pull/1116)
 - **.7**: Put `'%'` argument in `bufname()` for backwards compatibility. (PhilRunninger) [#1105](https://github.com/preservim/nerdtree/pull/1105)

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -377,8 +377,14 @@ endfunction
 "  1. If cascaded, we don't know which dir is bookmarked or is a symlink.
 "  2. If the parent is a symlink or is bookmarked, you end up with unparsable
 "     text, and NERDTree cannot get the path of any child node.
+" Also, return false if this directory is the tree root, which should never be
+" part of a cascade.
 function! s:TreeDirNode.isCascadable()
     if g:NERDTreeCascadeSingleChildDir ==# 0
+        return 0
+    endif
+
+    if self.isRoot()
         return 0
     endif
 


### PR DESCRIPTION
### Description of Changes

Do not consider the tree root to be "cascadable"

This PR fixes an un-handled error condition.  To reproduce:

1. `mkdir -p foo/bar/`
2. `cd foo/`
3. `vim`
4. `:NERDTree`
5. Position cursor on `bar/` in the NERDTree and hit `x`.

The result is a nasty error message because the handler for this command continues searching upward because it thinks the root `isCascadable()`.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
