### PR TITLE
* fix duplicated slash in s:Path.isUnder() (on windows OS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.11**: Fix exception in NERDTreeFind (on windows OS and If the file is located in the root directory of the disk)  [#1122](https://github.com/preservim/nerdtree/pull/1122)
 - **.10**: Do not consider the tree root to be "cascadable". (lifecrisis) [#1120](https://github.com/preservim/nerdtree/pull/1120)
 - **.9**: Force `:NERDTreeFocus` to allow events to be fired when switching windows. (PhilRunninger) [#1118](https://github.com/preservim/nerdtree/pull/1118)
 - **.8**: Fix example code for the `NERDTreeAddKeyMap()` function. (PhilRunninger) [#1116](https://github.com/preservim/nerdtree/pull/1116)

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -45,9 +45,7 @@ endfunction
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1
 " name: the name of a bookmark or a directory
 function! s:Creator.createTabTree(name)
-    echomsg "creating tabtree for ".a:name
     let l:path = self._pathForString(a:name)
-    echomsg "path = ".l:path.str()
 
     " Abort if an exception was thrown (i.e., if the bookmark or directory
     " does not exist).
@@ -65,13 +63,9 @@ function! s:Creator.createTabTree(name)
         call self._removeTreeBufForTab()
     endif
 
-    echomsg "creating window"
     call self._createTreeWin()
-    echomsg "creating nerdtree"
     call self._createNERDTree(l:path, 'tab')
-    echomsg "rendering"
     call b:NERDTree.render()
-    echomsg "moving cursor. Root=".b:NERDTree.root.path.str()
     call b:NERDTree.root.putCursorHere(0, 0)
 
     call self._broadcastInitEvent()
@@ -112,9 +106,8 @@ endfunction
 
 " FUNCTION: s:Creator._createNERDTree(path) {{{1
 function! s:Creator._createNERDTree(path, type)
-    echomsg "creating tree for ".a:path.str()
     let b:NERDTree = g:NERDTree.New(a:path, a:type)
-    echomsg "root is ".b:NERDTree.root.path.str()
+
     " TODO: This assignment is kept for compatibility reasons.  Many other
     " plugins use b:NERDTreeRoot instead of b:NERDTree.root.  Remove this
     " assignment in the future.
@@ -252,17 +245,15 @@ function! s:Creator._pathForString(str)
     else
         let dir = a:str ==# '' ? getcwd() : a:str
 
-        echomsg "1. dir = {".dir."}"
         "hack to get an absolute path if a relative path is given
         if dir =~# '^\.'
             let dir = getcwd() . g:NERDTreePath.Slash() . dir
         endif
-        echomsg "2. dir = {".dir."}"
+
         "hack to prevent removing slash if dir is the root of the file system.
         if dir !=# '/'
             let dir = g:NERDTreePath.Resolve(dir)
         endif
-        echomsg "3. dir = {".dir."}"
 
         try
             let path = g:NERDTreePath.New(dir)

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -45,7 +45,9 @@ endfunction
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1
 " name: the name of a bookmark or a directory
 function! s:Creator.createTabTree(name)
+    echomsg "creating tabtree for ".a:name
     let l:path = self._pathForString(a:name)
+    echomsg "path = ".l:path.str()
 
     " Abort if an exception was thrown (i.e., if the bookmark or directory
     " does not exist).
@@ -63,9 +65,13 @@ function! s:Creator.createTabTree(name)
         call self._removeTreeBufForTab()
     endif
 
+    echomsg "creating window"
     call self._createTreeWin()
+    echomsg "creating nerdtree"
     call self._createNERDTree(l:path, 'tab')
+    echomsg "rendering"
     call b:NERDTree.render()
+    echomsg "moving cursor. Root=".b:NERDTree.root.path.str()
     call b:NERDTree.root.putCursorHere(0, 0)
 
     call self._broadcastInitEvent()
@@ -106,8 +112,9 @@ endfunction
 
 " FUNCTION: s:Creator._createNERDTree(path) {{{1
 function! s:Creator._createNERDTree(path, type)
+    echomsg "creating tree for ".a:path.str()
     let b:NERDTree = g:NERDTree.New(a:path, a:type)
-
+    echomsg "root is ".b:NERDTree.root.path.str()
     " TODO: This assignment is kept for compatibility reasons.  Many other
     " plugins use b:NERDTreeRoot instead of b:NERDTree.root.  Remove this
     " assignment in the future.
@@ -245,11 +252,17 @@ function! s:Creator._pathForString(str)
     else
         let dir = a:str ==# '' ? getcwd() : a:str
 
+        echomsg "1. dir = {".dir."}"
         "hack to get an absolute path if a relative path is given
         if dir =~# '^\.'
             let dir = getcwd() . g:NERDTreePath.Slash() . dir
         endif
-        let dir = g:NERDTreePath.Resolve(dir)
+        echomsg "2. dir = {".dir."}"
+        "hack to prevent removing slash if dir is the root of the file system.
+        if dir !=# '/'
+            let dir = g:NERDTreePath.Resolve(dir)
+        endif
+        echomsg "3. dir = {".dir."}"
 
         try
             let path = g:NERDTreePath.New(dir)

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -547,13 +547,7 @@ endfunction
 "
 " a:path should be a dir
 function! s:Path.isAncestor(path)
-    if !self.isDirectory
-        return 0
-    endif
-
-    let this = self.str()
-    let that = a:path.str()
-    return stridx(that, this) ==# 0
+    return a:path.isUnder(self)
 endfunction
 
 " FUNCTION: Path.isUnder(path) {{{1
@@ -562,10 +556,26 @@ function! s:Path.isUnder(path)
     if a:path.isDirectory ==# 0
         return 0
     endif
-
-    let this = self.str()
-    let parent = substitute(a:path.str(), escape(s:Path.Slash().'$', '\'), '', '')
-    return stridx(this, parent . s:Path.Slash()) ==# 0
+    if nerdtree#runningWindows() && a:path.drive !=# self.drive
+        return 0
+    endif
+    let l:this_count = len(self.pathSegments)
+    if l:this_count ==# 0
+        return 0
+    endif
+    let l:that_count = len(a:path.pathSegments)
+    if l:that_count ==# 0
+        return 1
+    endif
+    if l:that_count >= l:this_count
+        return 0
+    endif
+    for i in range(0, l:that_count-1)
+        if self.pathSegments[i] !=# a:path.pathSegments[i]
+            return 0
+        endif
+    endfor
+    return 1
 endfunction
 
 " FUNCTION: Path.JoinPathStrings(...) {{{1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -564,8 +564,8 @@ function! s:Path.isUnder(path)
     endif
 
     let this = self.str()
-    let that = a:path.str()
-    return stridx(this, that . s:Path.Slash()) ==# 0
+    let parent = substitute(a:path.str(), escape(s:Path.Slash().'$', '\'), '', '')
+    return stridx(this, parent . s:Path.Slash()) ==# 0
 endfunction
 
 " FUNCTION: Path.JoinPathStrings(...) {{{1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -546,24 +546,24 @@ endfunction
 " return 1 if this path is somewhere above the given path in the filesystem.
 "
 " a:path should be a dir
-function! s:Path.isAncestor(path)
-    return a:path.isUnder(self)
+function! s:Path.isAncestor(child)
+    return a:child.isUnder(self)
 endfunction
 
 " FUNCTION: Path.isUnder(path) {{{1
 " return 1 if this path is somewhere under the given path in the filesystem.
-function! s:Path.isUnder(path)
-    if a:path.isDirectory ==# 0
+function! s:Path.isUnder(parent)
+    if a:parent.isDirectory ==# 0
         return 0
     endif
-    if nerdtree#runningWindows() && a:path.drive !=# self.drive
+    if nerdtree#runningWindows() && a:parent.drive !=# self.drive
         return 0
     endif
     let l:this_count = len(self.pathSegments)
     if l:this_count ==# 0
         return 0
     endif
-    let l:that_count = len(a:path.pathSegments)
+    let l:that_count = len(a:parent.pathSegments)
     if l:that_count ==# 0
         return 1
     endif
@@ -571,7 +571,7 @@ function! s:Path.isUnder(path)
         return 0
     endif
     for i in range(0, l:that_count-1)
-        if self.pathSegments[i] !=# a:path.pathSegments[i]
+        if self.pathSegments[i] !=# a:parent.pathSegments[i]
             return 0
         endif
     endfor


### PR DESCRIPTION
Fix exception in NERDTreeFind.
On windows OS and **if the file is located in the root directory of the disk**, TreeDirNode.reveal() trow exception because Path.isUnder() duplicate slash **on root drive paths** (look like "c://").

### Description of Changes
~~using substitute() to add a slash.~~
Rewrite NERDTreePath.isUnder() and NERDTreePath.isAncestor() for direct comparison of paths without transformations.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
