### PR TITLE
Fixed a bug that caused the file-tree construction to slow down significantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.12**: Fixed a bug that caused the file-tree construction to slow down significantly. [#1126](https://github.com/preservim/nerdtree/pull/1126)
 - **.11**: Fix exception in NERDTreeFind (on windows OS and If the file is located in the root directory of the disk)  [#1122](https://github.com/preservim/nerdtree/pull/1122)
 - **.10**: Do not consider the tree root to be "cascadable". (lifecrisis) [#1120](https://github.com/preservim/nerdtree/pull/1120)
 - **.9**: Force `:NERDTreeFocus` to allow events to be fired when switching windows. (PhilRunninger) [#1118](https://github.com/preservim/nerdtree/pull/1118)

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -431,6 +431,7 @@ function! s:TreeDirNode._initChildren(silent)
         endtry
     endfor
 
+    let g:NERDTreeOldSortOrder = g:NERDTreeSortOrder
     call self.sortChildren()
 
     call nerdtree#echo('')


### PR DESCRIPTION
### Description of Changes
The [sort](https://github.com/preservim/nerdtree/blob/e2670f0d190c9c0593ad7ac7b5708a4c198e423d/lib/nerdtree/tree_dir_node.vim#L669)() function called nerdtree#compareNodesBySortKey() which in turn called [getSortKey](https://github.com/preservim/nerdtree/blob/e2670f0d190c9c0593ad7ac7b5708a4c198e423d/lib/nerdtree/path.vim#L418)() for each comparison (~5996 times for a directory with 310 files), and unfortunately, getSortKey() re-created the sort key each time [because](https://github.com/preservim/nerdtree/blob/e2670f0d190c9c0593ad7ac7b5708a4c198e423d/lib/nerdtree/path.vim#L419) g:NERDTreeOldSortOrder was not set to g:NERDTreeSortOrder at the start.


---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
