### PR TITLE
Add curly braces to the list of characters to be escaped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.7
+- **.13**: Add curly braces to the list of characters to be escaped. (PhilRunninger) [#1128](https://github.com/preservim/nerdtree/pull/1128)
 - **.12**: Fixed a bug that caused the file-tree construction to slow down significantly. [#1126](https://github.com/preservim/nerdtree/pull/1126)
 - **.11**: Fix exception in NERDTreeFind (on windows OS and If the file is located in the root directory of the disk)  [#1122](https://github.com/preservim/nerdtree/pull/1122)
 - **.10**: Do not consider the tree root to be "cascadable". (lifecrisis) [#1120](https://github.com/preservim/nerdtree/pull/1120)

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -332,7 +332,7 @@ function! s:Path._escChars()
         return " `\|\"#%&,?()\*^<>$"
     endif
 
-    return " \\`\|\"#%&,?()\*^<>[]$"
+    return " \\`\|\"#%&,?()\*^<>[]{}$"
 endfunction
 
 " FUNCTION: Path.getDir() {{{1


### PR DESCRIPTION
### Description of Changes
Closes #1092  <!-- Issue number this PR addresses. If none, remove this line. -->

The combination of the `globpath()` function and the **fish** shell requires some additional care when it comes to filename characters that need to be escaped. In particular, when a path containing curly braces is used in the `globpath()` function, it fails in the fish shell, but works fine in bash. If those braces are escaped, then it works in both shells.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
