### PR TITLE
Allow concealed characters to show another character.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
      version in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.8
+- **.0**: Allow concealed characters to show another character. (PhilRunninger) [#1138](https://github.com/preservim/nerdtree/pull/1138)
 #### 6.7
 - **.15**: Add curly braces to the list of characters to be escaped. (PhilRunninger) [#1128](https://github.com/preservim/nerdtree/pull/1128)
 - **.14**: Use backward-compatible `nerdtree#and()` in one place that was missed. (PhilRunninger) [#1134](https://github.com/preservim/nerdtree/pull/1134)

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -22,7 +22,7 @@ syn match NERDTreeLinkDir #.*/ ->#me=e-3 containedin=NERDTreeDir
 "highlighting to conceal the delimiter around the file/dir name
 if has('conceal')
     exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# conceal containedin=ALL'
-    setlocal conceallevel=3 concealcursor=nvic
+    setlocal conceallevel=2 concealcursor=nvic
 else
     exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# containedin=ALL'
     hi! link NERDTreeNodeDelimiters Ignore


### PR DESCRIPTION
### Description of Changes
Closes #1136   <!-- Issue number this PR addresses. If none, remove this line. -->

conceallevel=3 always hides the character, but conceallevel=2 allows an alternate character to be displayed instead. This change, and a similar one in [nerdtree-buffer-ops](https://github.com/PhilRunninger/nerdtree-buffer-ops) will allow every other leading space in NERDTree to be displayed as a vertical bar, as described in my comment on #1136 .

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
