### PR TITLE
improved natural sorting mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.8
-- **.1**: Improved natural sorting mode. (Eugenij-W) [#1139](https://github.com/preservim/nerdtree/pull/1139)
+- **.1**: Support for outline numbering style in natural sorting mode. (Eugenij-W) [#1139](https://github.com/preservim/nerdtree/pull/1139)
 - **.0**: Allow concealed characters to show another character. (PhilRunninger) [#1138](https://github.com/preservim/nerdtree/pull/1138)
 #### 6.7
 - **.15**: Add curly braces to the list of characters to be escaped. (PhilRunninger) [#1128](https://github.com/preservim/nerdtree/pull/1128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.8
+- **.1**: Improved natural sorting mode. (Eugenij-W) [#1139](https://github.com/preservim/nerdtree/pull/1139)
 - **.0**: Allow concealed characters to show another character. (PhilRunninger) [#1138](https://github.com/preservim/nerdtree/pull/1138)
 #### 6.7
 - **.15**: Add curly braces to the list of characters to be escaped. (PhilRunninger) [#1128](https://github.com/preservim/nerdtree/pull/1128)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -121,7 +121,7 @@ function! nerdtree#compareNodesBySortKey(n1, n2) abort
     while i < min([len(sortKey1), len(sortKey2)])
         " Compare chunks upto common length.
         " If chunks have different type, the one which has
-        " integer type is the lesser.
+        " integer type is the greater.
         if type(sortKey1[i]) ==# type(sortKey2[i])
             if sortKey1[i] <# sortKey2[i]
                 return - 1

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -129,9 +129,9 @@ function! nerdtree#compareNodesBySortKey(n1, n2) abort
                 return 1
             endif
         elseif type(sortKey1[i]) ==# v:t_number
-            return -1
-        elseif type(sortKey2[i]) ==# v:t_number
             return 1
+        elseif type(sortKey2[i]) ==# v:t_number
+            return -1
         endif
         let i = i + 1
     endwhile

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -846,6 +846,23 @@ could appear like this: >
     z20.txt
     z3.txt
 <
+or like this: >
+    part-1-1-sfx.txt
+    part-1-2-sfx.txt
+    part-1-sfx.txt
+    part-2-1-sfx.txt
+    part-2-2-sfx.txt
+    part-2-3-1-sfx.txt
+    part-2-3-2-sfx.txt
+    part-2-3-3-sfx.txt
+    part-2-3-sfx.txt
+    part-2-sfx.txt
+    part-3-1-sfx.txt
+    part-3-2-sfx.txt
+    part-3-sfx.txt
+    part-4-1-sfx.txt
+    part-4-sfx.txt
+<
 But if you set this setting to 1 then the natural sort order will be used. The
 above nodes would then be sorted like this: >
     z1.txt
@@ -856,6 +873,23 @@ above nodes would then be sorted like this: >
     z20.txt
     z100.txt
     z110.txt
+<
+or like this: >
+    part-1-sfx.txt
+    part-1-1-sfx.txt
+    part-1-2-sfx.txt
+    part-2-sfx.txt
+    part-2-1-sfx.txt
+    part-2-2-sfx.txt
+    part-2-3-sfx.txt
+    part-2-3-1-sfx.txt
+    part-2-3-2-sfx.txt
+    part-2-3-3-sfx.txt
+    part-3-sfx.txt
+    part-3-1-sfx.txt
+    part-3-2-sfx.txt
+    part-4-sfx.txt
+    part-4-1-sfx.txt
 <
 ------------------------------------------------------------------------------
                                                                 *NERDTreeUseTCD*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -878,12 +878,6 @@ or like this: >
     part-2-3-sfx.txt
     part-2-3-1-sfx.txt
     part-2-3-2-sfx.txt
-    part-2-3-3-sfx.txt
-    part-3-sfx.txt
-    part-3-1-sfx.txt
-    part-3-2-sfx.txt
-    part-4-sfx.txt
-    part-4-1-sfx.txt
 <
 ------------------------------------------------------------------------------
                                                                 *NERDTreeUseTCD*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -854,14 +854,8 @@ or like this: >
     part-2-2-sfx.txt
     part-2-3-1-sfx.txt
     part-2-3-2-sfx.txt
-    part-2-3-3-sfx.txt
     part-2-3-sfx.txt
     part-2-sfx.txt
-    part-3-1-sfx.txt
-    part-3-2-sfx.txt
-    part-3-sfx.txt
-    part-4-1-sfx.txt
-    part-4-sfx.txt
 <
 But if you set this setting to 1 then the natural sort order will be used. The
 above nodes would then be sorted like this: >

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -403,17 +403,21 @@ endfunction
 function! s:Path._splitChunks(path)
     let chunks = split(a:path, '\([_.-]\+\|\D\+\|\d\+\)\zs')
     let i = 0
-    if match(chunks[0], '^\d\+$') ==# 0
+    if match(chunks[0], '^\d') ==# 0
         let chunks = insert(chunks, '/', 0)
-                let i = 1
-            endif
+        let i = 1
+    endif
     while i < len(chunks)
         "convert number literals to numbers
         if match(chunks[i], '^\d\+$') ==# 0
             let chunks[i] = str2nr(chunks[i])
+        elseif chunks[i] ==# '.'
+            let chunks = insert(chunks, '*', i)
+            let i = i + 1
         endif
         let i = i + 1
     endwhile
+    let chunks = add(chunks, '*')
     return chunks
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -401,15 +401,15 @@ endfunction
 " FUNCTION: Path._splitChunks(path) {{{1
 " returns a list of path chunks
 function! s:Path._splitChunks(path)
-    let chunks = split(a:path, '\(\D\+\|\d\+[_.-]\)\zs')
+    let chunks = split(a:path, '\([_.-]\+\|\D\+\|\d\+\)\zs')
     let i = 0
-    while i < len(chunks)
-        "convert number literals to numbers
-        if match(chunks[i], '^\d\+[_.-]$') ==# 0
-            if i == 0
-                let chunks = insert(chunks, '\x01', 0)
+    if match(chunks[0], '^\d\+$') ==# 0
+        let chunks = insert(chunks, '/', 0)
                 let i = 1
             endif
+    while i < len(chunks)
+        "convert number literals to numbers
+        if match(chunks[i], '^\d\+$') ==# 0
             let chunks[i] = str2nr(chunks[i])
         endif
         let i = i + 1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -401,11 +401,15 @@ endfunction
 " FUNCTION: Path._splitChunks(path) {{{1
 " returns a list of path chunks
 function! s:Path._splitChunks(path)
-    let chunks = split(a:path, '\(\D\+\|\d\+\)\zs')
+    let chunks = split(a:path, '\(\D\+\|\d\+[_.-]\)\zs')
     let i = 0
     while i < len(chunks)
         "convert number literals to numbers
-        if match(chunks[i], '^\d\+$') ==# 0
+        if match(chunks[i], '^\d\+[_.-]$') ==# 0
+            if i == 0
+                let chunks = insert(chunks, '\x01', 0)
+                let i = 1
+            endif
             let chunks[i] = str2nr(chunks[i])
         endif
         let i = i + 1


### PR DESCRIPTION
### Description of Changes
nerdtree's natural sorting (including numbering) does not take into account
outline numbering style:

    part-1-1-sfx.html
    part-1-2-sfx.html
    part-1-sfx.html
    part-2-1-sfx.html
    part-2-2-sfx.html
    part-2-3-1-sfx.html
    part-2-3-2-sfx.html
    part-2-3-3-sfx.html
    part-2-3-sfx.html
    part-2-sfx.html
    part-3-1-sfx.html
    part-3-2-sfx.html
    part-3-sfx.html
    part-4-1-sfx.html
    part-4-sfx.html

with these fixes, the list of files will look like this:

    part-1-sfx.html
    part-1-1-sfx.html
    part-1-2-sfx.html
    part-2-sfx.html
    part-2-1-sfx.html
    part-2-2-sfx.html
    part-2-3-sfx.html
    part-2-3-1-sfx.html
    part-2-3-2-sfx.html
    part-2-3-3-sfx.html
    part-3-sfx.html
    part-3-1-sfx.html
    part-3-2-sfx.html
    part-4-sfx.html
    part-4-1-sfx.html

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
