### PR TITLE
Fix argument of exists() function calls checking for autocommands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.9
+- **.7**: Fix argument of `exists()` function calls checking for autocommands. (PhilRunninger) [#1165](https://github.com/preservim/nerdtree/pull/1165)
 - **.6**: Don't use silent when raising User events (PhilRunninger) [#1164](https://github.com/preservim/nerdtree/pull/1164)
 - **.5**: Fix highlight for file node.  (pirey) [#1157](https://github.com/preservim/nerdtree/pull/1157)
 - **.4**: Make sure symbolic links' flags are highlighted correctly.  (PhilRunninger) [#1156](https://github.com/preservim/nerdtree/pull/1156)

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -28,7 +28,7 @@ endfunction
 
 " FUNCTION: s:Creator._broadcastInitEvent() {{{1
 function! s:Creator._broadcastInitEvent()
-    if exists('#NERDTreeInit')
+    if exists('#User#NERDTreeInit')
         doautocmd User NERDTreeInit
     endif
 endfunction

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -27,7 +27,7 @@ function! s:NERDTree.changeRoot(node)
     call self.render()
     call self.root.putCursorHere(0, 0)
 
-    if exists('#NERDTreeNewRoot')
+    if exists('#User#NERDTreeNewRoot')
         doautocmd User NERDTreeNewRoot
     endif
 endfunction


### PR DESCRIPTION
### Description of Changes
Closes #1163    <!-- Enter the issue number this PR addresses. If none, remove this line. -->

The `exists()` function needs to look for `#User#NERDTreeInit` instead of just `#NERDTreeInit`.


---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
