### PR TITLE
Refactor sort comparison functions, removing redundancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.9
+- **.8**: Refactor sort comparison functions, removing redundancy (PhilRunninger) [#1166](https://github.com/preservim/nerdtree/pull/1166)
 - **.7**: Fix argument of `exists()` function calls checking for autocommands. (PhilRunninger) [#1165](https://github.com/preservim/nerdtree/pull/1165)
 - **.6**: Don't use silent when raising User events (PhilRunninger) [#1164](https://github.com/preservim/nerdtree/pull/1164)
 - **.5**: Fix highlight for file node.  (pirey) [#1157](https://github.com/preservim/nerdtree/pull/1157)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -117,8 +117,13 @@ endfunction
 
 "FUNCTION: nerdtree#compareNodesBySortKey(n1, n2) {{{2
 function! nerdtree#compareNodesBySortKey(n1, n2) abort
-    let sortKey1 = a:n1.path.getSortKey()
-    let sortKey2 = a:n2.path.getSortKey()
+    return nerdtree#compareNodePathsBySortKey(a:n1.path, a:n2.path)
+endfunction
+
+"FUNCTION: nerdtree#compareNodePathsBySortKey(p1, p2) {{{2
+function! nerdtree#compareNodePathsBySortKey(p1, p2) abort
+    let sortKey1 = a:p1.getSortKey()
+    let sortKey2 = a:p2.getSortKey()
     let i = 0
     while i < min([len(sortKey1), len(sortKey2)])
         " Compare chunks upto common length.

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -110,18 +110,13 @@ function! nerdtree#completeBookmarks(A,L,P) abort
     return filter(g:NERDTreeBookmark.BookmarkNames(), 'v:val =~# "^' . a:A . '"')
 endfunction
 
-"FUNCTION: nerdtree#compareNodes(dir) {{{2
+"FUNCTION: nerdtree#compareNodes(n1, n2) {{{2
 function! nerdtree#compareNodes(n1, n2) abort
-    return a:n1.path.compareTo(a:n2.path)
+    return nerdtree#compareNodePaths(a:n1.path, a:n2.path)
 endfunction
 
-"FUNCTION: nerdtree#compareNodesBySortKey(n1, n2) {{{2
-function! nerdtree#compareNodesBySortKey(n1, n2) abort
-    return nerdtree#compareNodePathsBySortKey(a:n1.path, a:n2.path)
-endfunction
-
-"FUNCTION: nerdtree#compareNodePathsBySortKey(p1, p2) {{{2
-function! nerdtree#compareNodePathsBySortKey(p1, p2) abort
+"FUNCTION: nerdtree#compareNodePaths(p1, p2) {{{2
+function! nerdtree#compareNodePaths(p1, p2) abort
     let sortKey1 = a:p1.getSortKey()
     let sortKey2 = a:p2.getSortKey()
     let i = 0

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -99,50 +99,6 @@ function! s:Path.changeToDir()
     endtry
 endfunction
 
-" FUNCTION: Path.compareTo() {{{1
-"
-" Compares this Path to the given path and returns 0 if they are equal, -1 if
-" this Path is 'less than' the given path, or 1 if it is 'greater'.
-"
-" Args:
-" path: the path object to compare this to
-"
-" Return:
-" 1, -1 or 0
-function! s:Path.compareTo(path)
-    let thisPath = self.getLastPathComponent(1)
-    let thatPath = a:path.getLastPathComponent(1)
-
-    "if the paths are the same then clearly we return 0
-    if thisPath ==# thatPath
-        return 0
-    endif
-
-    let thisSS = self.getSortOrderIndex()
-    let thatSS = a:path.getSortOrderIndex()
-
-    "compare the sort sequences, if they are different then the return
-    "value is easy
-    if thisSS < thatSS
-        return -1
-    elseif thisSS > thatSS
-        return 1
-    else
-        if !g:NERDTreeSortHiddenFirst
-            let thisPath = substitute(thisPath, '^[._]', '', '')
-            let thatPath = substitute(thatPath, '^[._]', '', '')
-        endif
-        "if the sort sequences are the same then compare the paths
-        "alphabetically
-        let pathCompare = g:NERDTreeCaseSensitiveSort ? thisPath <# thatPath : thisPath <? thatPath
-        if pathCompare
-            return -1
-        else
-            return 1
-        endif
-    endif
-endfunction
-
 " FUNCTION: Path.Create(fullpath) {{{1
 "
 " Factory method.

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -666,7 +666,7 @@ function! s:TreeDirNode.sortChildren()
     if count(g:NERDTreeSortOrder, '*') < 1
         call add(g:NERDTreeSortOrder, '*')
     endif
-    let CompareFunc = function('nerdtree#compareNodesBySortKey')
+    let CompareFunc = function('nerdtree#compareNodes')
     call sort(self.children, CompareFunc)
     let g:NERDTreeOldSortOrder = g:NERDTreeSortOrder
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -236,7 +236,7 @@ function! s:TreeDirNode.getChildIndex(path)
     let z = self.getChildCount()
     while a < z
         let mid = (a+z)/2
-        let diff = a:path.compareTo(self.children[mid].path)
+        let diff = nerdtree#compareNodePaths(a:path, self.children[mid].path)
 
         if diff ==# -1
             let z = mid


### PR DESCRIPTION
### Description of Changes
When researching #1162, I discovered a pair of functions that were doing very much the same thing: `Path.compareTo(path)` and `nerdtree#compareNodesBySortKey(n1,n2)`. I removed the `compareTo` function, and used the more robust `compareNodesBySortKey` function instead.

Speaking of `compareNodesBySortKey`, there was another function named `compareNodes` that appeared to be unused. On the off chance that was written for other plugins, I decided to keep that function, refactored to fit the new structure.

I also added a new function to accept two path objects instead of node objects. It's named `nerdtree#compareNodePaths`, and to keep things simple, it is called by `nerdtree#compareNodes`.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
