### PR TITLE
Fix {'keepopen':0} in NERDTreeCustomOpenArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.10
+- **.4**: Fix `{'keepopen':0}` in NERDTreeCustomOpenArgs (PhilRunninger) [#1217](https://github.com/preservim/nerdtree/pull/1217)
 - **.3**: Add new FAQ and answer: How to prevent buffers replacing NERDTree. (PhilRunninger) [#1215](https://github.com/preservim/nerdtree/pull/1215)
 - **.2**: New menu command: Run a system command in this directory. (PhilRunninger) [#1214](https://github.com/preservim/nerdtree/pull/1214)
 - **.1**: Escape quotation marks so they can be used in key mappings. (PhilRunninger) [#1213](https://github.com/preservim/nerdtree/pull/1213)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -30,6 +30,16 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
+" FUNCTION: nerdtree#closeTreeOnOpen()
+function! nerdtree#closeTreeOnOpen() abort
+    return g:NERDTreeQuitOnOpen == 1 || g:NERDTreeQuitOnOpen == 3
+endfunction
+
+" FUNCTION: nerdtree#closeBookmarksOnOpen()
+function! nerdtree#closeBookmarksOnOpen() abort
+    return g:NERDTreeQuitOnOpen == 2 || g:NERDTreeQuitOnOpen == 3
+endfunction
+
 " FUNCTION: nerdtree#slash() {{{2
 " Return the path separator used by the underlying file system.  Special
 " consideration is taken for the use of the 'shellslash' option on Windows
@@ -44,28 +54,6 @@ function! nerdtree#slash() abort
     endif
 
     return '/'
-endfunction
-
-"FUNCTION: nerdtree#and(x,y) {{{2
-" Implements and() function for Vim <= 7.4
-function! nerdtree#and(x,y) abort
-    if exists('*and')
-        return and(a:x, a:y)
-    else
-        let l:x = a:x
-        let l:y = a:y
-        let l:n = 0
-        let l:result = 0
-        while l:x > 0 && l:y > 0
-            if (l:x % 2) && (l:y % 2)
-                let l:result += float2nr(pow(2, l:n))
-            endif
-            let l:x = float2nr(l:x / 2)
-            let l:y = float2nr(l:y / 2)
-            let l:n += 1
-        endwhile
-        return l:result
-    endif
 endfunction
 
 "FUNCTION: nerdtree#checkForBrowse(dir) {{{2

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -174,7 +174,7 @@ endfunction
 "FUNCTION: s:activateBookmark(bookmark) {{{1
 "handle the user activating a bookmark
 function! s:activateBookmark(bm) abort
-    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p'} : {'keepopen': !nerdtree#closeTreeOnOpen()})
+    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p', 'keepopen': !nerdtree#closeTreeOnOpen()} : {})
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#bookmarkNode(name) {{{1

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -168,13 +168,13 @@ endfunction
 "FUNCTION: s:activateFileNode() {{{1
 "handle the user activating a tree node
 function! s:activateFileNode(node) abort
-    call a:node.activate({'reuse': 'all', 'where': 'p'})
+    call a:node.activate({'reuse': 'all', 'where': 'p', 'keepopen': !nerdtree#closeTreeOnOpen()})
 endfunction
 
 "FUNCTION: s:activateBookmark(bookmark) {{{1
 "handle the user activating a bookmark
 function! s:activateBookmark(bm) abort
-    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p'} : {})
+    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p'} : {'keepopen': !nerdtree#closeTreeOnOpen()})
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#bookmarkNode(name) {{{1
@@ -539,24 +539,24 @@ endfunction
 
 " FUNCTION: s:openHSplit(target) {{{1
 function! s:openHSplit(target) abort
-    call a:target.activate({'where': 'h'})
+    call a:target.activate({'where': 'h', 'keepopen': !nerdtree#closeTreeOnOpen()})
 endfunction
 
 " FUNCTION: s:openVSplit(target) {{{1
 function! s:openVSplit(target) abort
-    call a:target.activate({'where': 'v'})
+    call a:target.activate({'where': 'v', 'keepopen': !nerdtree#closeTreeOnOpen()})
 endfunction
 
 "FUNCTION: s:openHSplitBookmark(bookmark) {{{1
 "handle the user activating a bookmark
 function! s:openHSplitBookmark(bm) abort
-    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'h'} : {})
+    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'h', 'keepopen': !nerdtree#closeTreeOnOpen()} : {})
 endfunction
 
 "FUNCTION: s:openVSplitBookmark(bookmark) {{{1
 "handle the user activating a bookmark
 function! s:openVSplitBookmark(bm) abort
-    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'v'} : {})
+    call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'v', 'keepopen': !nerdtree#closeTreeOnOpen()} : {})
 endfunction
 
 " FUNCTION: s:previewHSplitBookmark(bookmark) {{{1
@@ -576,13 +576,13 @@ endfunction
 
 " FUNCTION: s:openInNewTab(target) {{{1
 function! s:openInNewTab(target) abort
-    let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't'})
+    let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't', 'keepopen': !nerdtree#closeTreeOnOpen()})
     call l:opener.open(a:target)
 endfunction
 
 " FUNCTION: s:openInNewTabSilent(target) {{{1
 function! s:openInNewTabSilent(target) abort
-    let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't', 'stay': 1})
+    let l:opener = g:NERDTreeOpener.New(a:target.path, {'where': 't', 'keepopen': !nerdtree#closeTreeOnOpen(), 'stay': 1})
     call l:opener.open(a:target)
 endfunction
 
@@ -621,7 +621,7 @@ function! nerdtree#ui_glue#revealBookmark(name) abort
         let targetNode = g:NERDTreeBookmark.GetNodeForName(a:name, 0, b:NERDTree)
         call targetNode.putCursorHere(0, 1)
     catch /^NERDTree.BookmarkNotFoundError/
-        call nerdtree#echo('Bookmark isnt cached under the current root')
+        call nerdtree#echo('Bookmark isn''t cached under the current root')
     endtry
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -596,7 +596,7 @@ endfunction
 
 " FUNCTION: s:previewBookmark(bookmark) {{{1
 function! s:previewBookmark(bookmark) abort
-    call a:bookmark.activate(b:NERDTree, !a:bookmark.path.isDirectory ? {'stay': 1, 'where': 'h', 'keepopen': 1} : {})
+    call a:bookmark.activate(b:NERDTree, !a:bookmark.path.isDirectory ? {'stay': 1, 'where': 'p', 'keepopen': 1} : {})
 endfunction
 
 "FUNCTION: s:previewNodeCurrent(node) {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -256,7 +256,7 @@ endfunction
 function! s:Bookmark.open(nerdtree, ...)
     let opts = a:0 ? a:1 : {}
 
-    if nerdtree#and(g:NERDTreeQuitOnOpen,2)
+    if nerdtree#closeBookmarksOnOpen()
         call a:nerdtree.ui.toggleShowBookmarks()
     endif
 

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -65,14 +65,6 @@ function! s:NERDTree.Close()
     endif
 endfunction
 
-"FUNCTION: s:NERDTree.CloseIfQuitOnOpen() {{{1
-"Closes the NERD tree window if the close on open option is set
-function! s:NERDTree.CloseIfQuitOnOpen()
-    if nerdtree#and(g:NERDTreeQuitOnOpen,1) && s:NERDTree.IsOpen()
-        call s:NERDTree.Close()
-    endif
-endfunction
-
 "FUNCTION: s:NERDTree.CursorToBookmarkTable(){{{1
 "Places the cursor at the top of the bookmarks table
 function! s:NERDTree.CursorToBookmarkTable()

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -33,8 +33,7 @@ function! s:Opener._bufInWindows(bnum)
 endfunction
 
 " FUNCTION: Opener._checkToCloseTree(newtab) {{{1
-" Check the class options and global options (i.e. NERDTreeQuitOnOpen) to see
-" if the tree should be closed now.
+" Check the class options to see if the tree should be closed now.
 "
 " Args:
 " a:newtab - boolean. If set, only close the tree now if we are opening the

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -218,7 +218,7 @@ endfunction
 
 " FUNCTION: Opener._openFile() {{{1
 function! s:Opener._openFile()
-    if !self._stay && self._keepopen && exists('b:NERDTreeZoomed') && b:NERDTreeZoomed
+    if !self._stay && self._keepopen && get(b:, 'NERDTreeZoomed', 0)
         call b:NERDTree.ui.toggleZoom()
     endif
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -46,7 +46,7 @@ function! s:Opener._checkToCloseTree(newtab)
     endif
 
     if (a:newtab && self._where ==# 't') || !a:newtab
-        call s:NERDTree.Close()
+        call g:NERDTree.Close()
     endif
 endfunction
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -46,7 +46,7 @@ function! s:Opener._checkToCloseTree(newtab)
     endif
 
     if (a:newtab && self._where ==# 't') || !a:newtab
-        call g:NERDTree.CloseIfQuitOnOpen()
+        call s:NERDTree.Close()
     endif
 endfunction
 
@@ -218,7 +218,7 @@ endfunction
 
 " FUNCTION: Opener._openFile() {{{1
 function! s:Opener._openFile()
-    if !self._stay && !nerdtree#and(g:NERDTreeQuitOnOpen,1) && exists('b:NERDTreeZoomed') && b:NERDTreeZoomed
+    if !self._stay && self._keepopen && exists('b:NERDTreeZoomed') && b:NERDTreeZoomed
         call b:NERDTree.ui.toggleZoom()
     endif
 


### PR DESCRIPTION
### Description of Changes
Closes #1168    <!-- Enter the issue number this PR addresses. If none, remove this line. -->

When `{'keepopen': 0}` was specified in `NERDTreeCustomOpenArgs` the value of `NERDTreeQuitOnOpen` was overriding that value in the dictionary, not letting you define `o` to keep NERDTree open, and `<CR>` to close it.

This PR pushes the differentiating behavior of the `NERDTreeQuitOnOpen` setting up to an earlier point in the call stack, either keeping or resetting the `keepopen' value for the key mappings as appropriate. 

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
