### PR TITLE
Restore the default behavior of the <CR> key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.10
+- **.6**: Restore the default behavior of the <CR> key. (PhilRunninger) [#1221](https://github.com/preservim/nerdtree/pull/1221)
 - **.5**: Fix `{'keepopen':0}` in NERDTreeCustomOpenArgs (PhilRunninger) [#1217](https://github.com/preservim/nerdtree/pull/1217)
 - **.4**: Removed directory separator from sort key (Daniel E) [#1219](https://github.com/preservim/nerdtree/pull/1219)
 - **.3**: Add new FAQ and answer: How to prevent buffers replacing NERDTree. (PhilRunninger) [#1215](https://github.com/preservim/nerdtree/pull/1215)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -30,12 +30,12 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
-" FUNCTION: nerdtree#closeTreeOnOpen()
+" FUNCTION: nerdtree#closeTreeOnOpen() {{{2
 function! nerdtree#closeTreeOnOpen() abort
     return g:NERDTreeQuitOnOpen == 1 || g:NERDTreeQuitOnOpen == 3
 endfunction
 
-" FUNCTION: nerdtree#closeBookmarksOnOpen()
+" FUNCTION: nerdtree#closeBookmarksOnOpen() {{{2
 function! nerdtree#closeBookmarksOnOpen() abort
     return g:NERDTreeQuitOnOpen == 2 || g:NERDTreeQuitOnOpen == 3
 endfunction

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -110,39 +110,15 @@ endfunction
 "FUNCTION: s:initCustomOpenArgs() {{{1
 function! s:initCustomOpenArgs() abort
     let l:defaultOpenArgs = {'file': {'reuse': 'all', 'where': 'p', 'keepopen':!nerdtree#closeTreeOnOpen()}, 'dir': {}}
-    let l:customOpenArgs = get(g:, 'NERDTreeCustomOpenArgs', {})
-
-    if !s:validateType(l:customOpenArgs, type({})) || empty(l:customOpenArgs)
-        let g:NERDTreeCustomOpenArgs = l:customOpenArgs
-        return l:defaultOpenArgs
-    endif
-
-    for l:typeKey in keys(l:defaultOpenArgs)
-        if !s:validateType(get(l:customOpenArgs, l:typeKey, {}), type({}))
-              \ || !has_key(l:customOpenArgs, l:typeKey)
-            let l:customOpenArgs[l:typeKey] = l:defaultOpenArgs[l:typeKey]
-            continue
-        endif
-
-        for l:optionName in keys(l:defaultOpenArgs[l:typeKey])
-            if s:validateType(get(l:customOpenArgs[l:typeKey], l:optionName, v:null), type(''))
-                continue
-            endif
-            let l:customOpenArgs[l:typeKey][l:optionName] = l:defaultOpenArgs[l:typeKey][l:optionName]
-        endfor
-    endfor
-
-    let g:NERDTreeCustomOpenArgs = l:customOpenArgs
-
-    return extend(l:customOpenArgs, l:defaultOpenArgs, 'keep')
-endfunction
-
-function! s:validateType(variable, type) abort
-    if type(a:variable) == a:type
-        return v:true
-    endif
-
-    return v:false
+    try
+        let g:NERDTreeCustomOpenArgs = get(g:, 'NERDTreeCustomOpenArgs', {})
+        call  extend(g:NERDTreeCustomOpenArgs, l:defaultOpenArgs, 'keep')
+    catch /^Vim(\a\+):E712:/
+        call nerdtree#echoWarning('g:NERDTreeCustomOpenArgs is not set properly. Using default value.')
+        let g:NERDTreeCustomOpenArgs = l:defaultOpenArgs
+    finally
+        return g:NERDTreeCustomOpenArgs
+    endtry
 endfunction
 
 "FUNCTION: s:activateAll() {{{1

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -109,7 +109,7 @@ endfunction
 
 "FUNCTION: s:initCustomOpenArgs() {{{1
 function! s:initCustomOpenArgs() abort
-    let l:defaultOpenArgs = {'file': {'reuse': 'all', 'where': 'p'}, 'dir': {}}
+    let l:defaultOpenArgs = {'file': {'reuse': 'all', 'where': 'p', 'keepopen':!nerdtree#closeTreeOnOpen()}, 'dir': {}}
     let l:customOpenArgs = get(g:, 'NERDTreeCustomOpenArgs', {})
 
     if !s:validateType(l:customOpenArgs, type({})) || empty(l:customOpenArgs)


### PR DESCRIPTION
### Description of Changes
Closes #1220     <!-- Enter the issue number this PR addresses. If none, remove this line. -->

#1217 was created to address the specific case of the user-specified value `'keepopen':0` in `g:NERDTreeCustomOpenArgs`. When working on that, I'd forgotten to test the default case. This function restores the correct default behavior of the `<CR>` key, which is to act the same way as `o`.

---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
