### PR TITLE
Added `NERDTreeHighlightCursorcolumn` option to toggle `cursorcolumn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.10
+- **.9**: Added `NERDTreeHighlightCursorcolumn` option to toggle `cursorcolumn` (samyak039) [#1231](https://github.com/preservim/nerdtree/pull/1231)
 - **.8**: Put `Callback` function variables in local scope. [#1230](https://github.com/preservim/nerdtree/pull/1230)
 - **.7**: Fix mouse-clicking a file to open it. (PhilRunninger) [#1225](https://github.com/preservim/nerdtree/pull/1225)
 - **.6**: Restore the default behavior of the <CR> key. (PhilRunninger) [#1221](https://github.com/preservim/nerdtree/pull/1221)

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -689,6 +689,10 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeHighlightCursorline| Tell the NERDTree whether to highlight the
                             current cursor line.
 
+NERDTreeHighlightCursorcolumn
+                            Tell the NERDTree whether to highlight the
+                            current cursor column.
+
 |NERDTreeHijackNetrw|         Tell the NERDTree whether to replace the netrw
                             autocommands for exploring local directories.
 
@@ -897,6 +901,14 @@ Default: 1.
 
 If set to 1, the current cursor line in the NERDTree buffer will be
 highlighted. This is done using the `'cursorline'` Vim option.
+
+-----------------------------------------------------------------------------
+                                                NERDTreeHighlightCursorcolumn
+Values: 0 or 1.
+Default: 0.
+
+If set to 1, the current cursor column in the NERDTree buffer will be
+highlighted. This is done using the 'cursorcolumn' Vim option.
 
 ------------------------------------------------------------------------------
                                                            *NERDTreeHijackNetrw*

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -319,6 +319,14 @@ function! s:Creator._setCommonBufOptions()
 
     if g:NERDTreeHighlightCursorline
         setlocal cursorline
+    else
+        setlocal nocursorline
+    endif
+
+    if g:NERDTreeHighlightCursorcolumn
+        setlocal cursorcolumn
+    else
+        setlocal nocursorcolumn
     endif
 
     call self._setupStatusline()

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -41,6 +41,7 @@ let g:NERDTreeIgnore                = get(g:, 'NERDTreeIgnore',                [
 let g:NERDTreeBookmarksFile         = get(g:, 'NERDTreeBookmarksFile',         expand('$HOME') . '/.NERDTreeBookmarks')
 let g:NERDTreeBookmarksSort         = get(g:, 'NERDTreeBookmarksSort',         1)
 let g:NERDTreeHighlightCursorline   = get(g:, 'NERDTreeHighlightCursorline',   1)
+let g:NERDTreeHighlightCursorcolumn = get(g:, 'NERDTREEHighlightCursorcolumn', 0)
 let g:NERDTreeHijackNetrw           = get(g:, 'NERDTreeHijackNetrw',           1)
 let g:NERDTreeMarkBookmarks         = get(g:, 'NERDTreeMarkBookmarks',         1)
 let g:NERDTreeMouseMode             = get(g:, 'NERDTreeMouseMode',             1)


### PR DESCRIPTION
### Description of Changes
Closes #    <!-- Enter the issue number this PR addresses. If none, remove this line. -->

- added the else case for `g:NERDTreeHighlightCursorline`, to make it work properly
- added `g:NERDTreeHighlightCursorcolumn`, because I use `cursorcolumn` in my config but there was no option to disable it in the NERDTree

---
### New Version Info

#### Author's Instructions
- [X] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [X] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
