### PR TITLE
This adds split explorer capability to NERDTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
      version in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.11
+- **.0**: Add split explorer capability to NERDTREE (tempoz) [#1237](https://github.com/preservim/nerdtree/pull/1237)
 #### 6.10
 - **.9**: `go` on a bookmark directory will NERDTreeFind it. (PhilRunninger) [#1236](https://github.com/preservim/nerdtree/pull/1236)
 - **.8**: Put `Callback` function variables in local scope. (PhilRunninger) [#1230](https://github.com/preservim/nerdtree/pull/1230)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -324,9 +324,9 @@ function! s:findAndRevealPath(pathStr) abort
         endtry
 
         if l:pathObj.isUnder(l:cwd)
-            call g:NERDTreeCreator.CreateTabTree(l:cwd.str())
+            call g:NERDTreeCreator.CreateDefaultTree(l:cwd.str())
         else
-            call g:NERDTreeCreator.CreateTabTree(l:pathObj.getParent().str())
+            call g:NERDTreeCreator.CreateDefaultTree(l:pathObj.getParent().str())
         endif
     else
         NERDTreeFocus
@@ -639,10 +639,10 @@ endfunction
 
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
 function! nerdtree#ui_glue#setupCommands() abort
-    command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
+    command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateDefaultTree('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
-    command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')
+    command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateDefaultTree('<args>')
     command! -n=0 -bar NERDTreeMirror call g:NERDTreeCreator.CreateMirror()
     command! -n=? -complete=file -bar NERDTreeFind call s:findAndRevealPath('<args>')
     command! -n=0 -bar NERDTreeRefreshRoot call s:refreshRoot()

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1305,6 +1305,22 @@ To open files and directories (creating a new NERDTree) in a new tab, >
 To open a file always in the current tab, and expand directories in place, >
     {'file': {'reuse':'currenttab', 'where':'p', 'keepopen':1, 'stay':1}}
 <
+------------------------------------------------------------------------------
+                                                             *NERDTreeSplexMode*
+Values: 0 or 1
+Default: 0.
+
+Changes the default behavior of NERDTree from its standard "project drawer"
+style (where NERDTree appears in its own window on one side of a tab) to a
+"split explorer" style (where NERDTree opens a buffer in the current window
+and then swaps the previous buffer back into place after a file is opened in a
+split, or simply swaps the new buffer into place if a file is opened
+standardly). This is especially useful if you are low on screen space or find
+the splits done in the project drawer mode to be hard to follow. Use one of the
+following lines for this setting: >
+    let NERDTreeSplexMode=0
+    let NERDTreeSplexMode=1
+<
 ==============================================================================
 4. The NERDTree API                                                *NERDTreeAPI*
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -109,6 +109,17 @@ function! s:Creator.createWindowTree(dir)
     call self._broadcastInitEvent()
 endfunction
 
+" FUNCTION: s:Creator.CreateDefaultTree(dir) {{{1
+function! s:Creator.CreateDefaultTree(dir)
+    let creator = s:Creator.New()
+    if g:NERDTreeSplexMode
+        enew
+        call creator.createWindowTree(a:dir)
+    else
+        call creator.createTabTree(a:dir)
+    endif
+endfunction
+
 " FUNCTION: s:Creator._createNERDTree(path) {{{1
 function! s:Creator._createNERDTree(path, type)
     let b:NERDTree = g:NERDTree.New(a:path, a:type)

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -93,13 +93,16 @@ function! s:Creator.createWindowTree(dir)
 
     let previousBuf = expand('#')
 
+    let bufferName = self._nextBufferName()
     "we need a unique name for each window tree buffer to ensure they are
     "all independent
-    exec g:NERDTreeCreatePrefix . ' edit ' . self._nextBufferName()
+    exec g:NERDTreeCreatePrefix . ' edit ' . bufferName
 
     call self._createNERDTree(path, 'window')
     let b:NERDTree._previousBuf = bufnr(previousBuf)
     call self._setCommonBufOptions()
+
+    let t:NERDTreeBufName = bufferName
 
     call b:NERDTree.render()
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -157,12 +157,17 @@ function! s:Opener._newSplit()
     if onlyOneWin
         let &splitright = (g:NERDTreeWinPos ==# 'left')
     endif
+
     " If only one window (ie. NERDTree), split vertically instead.
-    let splitMode = onlyOneWin ? 'vertical' : ''
+    let splitMode = onlyOneWin && !g:NERDTreeSplexMode ? 'vertical' : ''
 
     " Open the new window
     try
-        call nerdtree#exec('wincmd p', 1)
+        if g:NERDTreeSplexMode
+            call nerdtree#exec('buffer ' . b:NERDTree.previousBuf(), 1)
+        else
+            call nerdtree#exec('wincmd p', 1)
+        endif
         call nerdtree#exec(splitMode . ' split',1)
     catch /^Vim\%((\a\+)\)\=:E37/
         call g:NERDTree.CursorToTreeWin()
@@ -172,7 +177,7 @@ function! s:Opener._newSplit()
     endtry
 
     "resize the tree window if no other window was open before
-    if onlyOneWin
+    if onlyOneWin && !g:NERDTreeSplexMode
         call nerdtree#exec('wincmd p', 1)
         call nerdtree#exec('silent '. splitMode .' resize '. g:NERDTreeWinSize, 1)
         call nerdtree#exec('wincmd p', 0)
@@ -192,16 +197,22 @@ function! s:Opener._newVSplit()
         let l:winwidth = g:NERDTreeWinSize
     endif
 
-    call nerdtree#exec('wincmd p', 1)
+    if g:NERDTreeSplexMode
+        call nerdtree#exec('buffer ' . b:NERDTree.previousBuf(), 1)
+    else
+        call nerdtree#exec('wincmd p', 1)
+    endif
     call nerdtree#exec('vsplit', 1)
 
-    let l:currentWindowNumber = winnr()
+    if !g:NERDTreeSplexMode
+        let l:currentWindowNumber = winnr()
 
-    " Restore the NERDTree to its original width.
-    call g:NERDTree.CursorToTreeWin()
-    execute 'silent vertical resize ' . l:winwidth
+        " Restore the NERDTree to its original width.
+        call g:NERDTree.CursorToTreeWin()
+        execute 'silent vertical resize ' . l:winwidth
 
-    call nerdtree#exec(l:currentWindowNumber . 'wincmd w', 0)
+        call nerdtree#exec(l:currentWindowNumber . 'wincmd w', 0)
+    endif
     let &splitright=savesplitright
 endfunction
 

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -10,14 +10,14 @@
 "              See http://sam.zoy.org/wtfpl/COPYING for more details.
 "
 " ============================================================================
-command! -n=? -complete=dir -bar NERDTreeVCS :call <SID>CreateTabTreeVCS('<args>')
+command! -n=? -complete=dir -bar NERDTreeVCS :call <SID>CreateDefaultTreeVCS('<args>')
 command! -n=? -complete=dir -bar NERDTreeToggleVCS :call <SID>ToggleTabTreeVCS('<args>')
 
 " FUNCTION: s:CreateTabTreeVCS(a:name) {{{1
-function! s:CreateTabTreeVCS(name)
+function! s:CreateDefaultTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)
     let l:path = s:FindParentVCSRoot(l:path)
-    call g:NERDTreeCreator.createTabTree(empty(l:path) ? '' : l:path._str())
+    call g:NERDTreeCreator.CreateDefaultTree(empty(l:path) ? '' : l:path._str())
 endfunction
 
 " FUNCTION: s:ToggleTabTreeVCS(a:name) {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -194,7 +194,11 @@ function! NERDTreeFocus()
     if g:NERDTree.IsOpen()
         call g:NERDTree.CursorToTreeWin(0)
     else
-        call g:NERDTreeCreator.ToggleTabTree('')
+        if g:NERDTreeSplexMode
+            call g:NERDTreeCreator.CreateDefaultTree('')
+        else
+            call g:NERDTreeCreator.ToggleTabTree('')
+        endif
     endif
 endfunction
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -96,6 +96,8 @@ else
     let g:NERDTreeCopyCmd      = get(g:, 'NERDTreeCopyCmd',      'cp -r ')
 endif
 
+let g:NERDTreeSplexMode = get(g:, 'NERDTreeSplexMode', 0)
+
 "SECTION: Init variable calls for key mappings {{{2
 let g:NERDTreeMapCustomOpen      = get(g:, 'NERDTreeMapCustomOpen',      '<CR>')
 let g:NERDTreeMapActivateNode    = get(g:, 'NERDTreeMapActivateNode',    'o')


### PR DESCRIPTION
### Description of Changes

This adds a `g:NERDTreeSplexMode` boolean setting that, when activated, causes NERDTree to [act as split explorer-style file browser instead of a project drawer](http://vimcasts.org/blog/2013/01/oil-and-vinegar-split-windows-and-project-drawer/).

### Motivation for Changes

I was looking for a way to browse my filesystem in vim and I came across NERDTree, which I love the look and feel of, but in my search I had also come across many articles extolling the virtues of split explorer-style browsers. Given my restricted monitor space and preference for more intuitive window-splitting, I decided to try to do both. I understand entirely if the project maintainers do not wish to support this feature, but since I'd gone to the trouble of developing it, I thought I'd offer it up.

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
