### PR TITLE
Trim filenames created via the fs_menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.10
+- **.10**: Trim filenames created via the fs_menu (elanorigby) [#1243](https://github.com/preservim/nerdtree/pull/1243)
 - **.9**: `go` on a bookmark directory will NERDTreeFind it. (PhilRunninger) [#1236](https://github.com/preservim/nerdtree/pull/1236)
 - **.8**: Put `Callback` function variables in local scope. (PhilRunninger) [#1230](https://github.com/preservim/nerdtree/pull/1230)
 - **.7**: Fix mouse-clicking a file to open it. (PhilRunninger) [#1225](https://github.com/preservim/nerdtree/pull/1225)

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -169,7 +169,7 @@ endfunction
 function! NERDTreeAddNode()
     let curDirNode = g:NERDTreeDirNode.GetSelected()
     let prompt = s:inputPrompt('add')
-    let newNodeName = input(prompt, curDirNode.path.str() . nerdtree#slash(), 'file')
+    let newNodeName = trim(input(prompt, curDirNode.path.str() . nerdtree#slash(), 'file'))
 
     if newNodeName ==# ''
         call nerdtree#echo('Node Creation Aborted.')
@@ -206,7 +206,7 @@ function! NERDTreeMoveNode()
     let newNodePath = input(prompt, curNode.path.str(), 'file')
     while filereadable(newNodePath)
         call nerdtree#echoWarning('This destination already exists. Try again.')
-        let newNodePath = input(prompt, curNode.path.str(), 'file')
+        let newNodePath = trim(input(prompt, curNode.path.str(), 'file'))
     endwhile
 
 
@@ -337,7 +337,7 @@ endfunction
 function! NERDTreeCopyNode()
     let currentNode = g:NERDTreeFileNode.GetSelected()
     let prompt = s:inputPrompt('copy')
-    let newNodePath = input(prompt, currentNode.path.str(), 'file')
+    let newNodePath = trim(input(prompt, currentNode.path.str(), 'file'))
 
     if newNodePath !=# ''
         "strip trailing slash


### PR DESCRIPTION
I found out today that a file I created via the fs_code nerdtree menu had a space character at the end of its name. This is at minimum embarassing, but could be worse (it just broke some tests in this case). I would like technology to save me from such mistakes if possible. 
The default when naming a file in the command line is that extra white space will be stripped away. It seems logical for file naming via the fs_menu in nerdtree to follow that convention.

### Description of Changes
Wrap `newNodeName` inputs in `trim()` to get rid of excess whitespace.

I have left the defaults of `trim` because they seem sensible, but the exact characters that are trimmed away can be customized via a mask argument - https://github.com/vim/vim/commit/295ac5ab5e840af6051bed5ec9d9acc3c73445de

### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
