### PR TITLE
Add 'b' binding to jump to bookmark table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
 #### 6.10
+- **.17**: Add 'b' binding to to jump to bookmark table. (ds2606) [#1305](https://github.com/preservim/nerdtree/pull/1305)
 - **.16**: Fix documentation errors. (lifecrisis) [#1269](https://github.com/preservim/nerdtree/pull/1269)
 - **.15**: Ensure backward compatible testing of types. (lifecrisis) [#1266](https://github.com/preservim/nerdtree/pull/1266)
 - **.14**: Replace trim() with a version-compatible alternative. (PhilRunninger) [#1265](https://github.com/preservim/nerdtree/pull/1265)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -69,6 +69,7 @@ function! nerdtree#ui_glue#createDefaultBindings() abort
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpRoot, 'scope': 'all', 'callback': s.'jumpToRoot' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpNextSibling, 'scope': 'Node', 'callback': s.'jumpToNextSibling' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpPrevSibling, 'scope': 'Node', 'callback': s.'jumpToPrevSibling' })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapJumpBookmarks, 'scope': 'all', 'callback': s.'jumpToBookmarks' })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTab, 'scope': 'Node', 'callback': s . 'openInNewTab' })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenInTabSilent, 'scope': 'Node', 'callback': s . 'openInNewTabSilent' })
@@ -493,6 +494,17 @@ function! s:jumpToSibling(node, forward) abort
 
     call l:sibling.putCursorHere(1, 0)
     call b:NERDTree.ui.centerView()
+endfunction
+
+" FUNCTION: s:jumpToBookmarks() {{{1
+" moves the cursor to the bookmark listing
+function! s:jumpToBookmarks() abort
+    try
+        call g:NERDTree.CursorToBookmarkTable()
+    catch /^NERDTree.BookmarkTableNotFoundError\|^NERDTree.IllegalOperationError/
+        call nerdtree#echoError('bookmark table is closed')
+        return
+    endtry
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#openBookmark(name) {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -62,6 +62,7 @@ function! s:UI._dumpHelp()
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Bookmark table mappings~\n"
         let help .= "\" double-click,\n"
+        let help .= '" '. g:NERDTreeMapJumpBookmarks .": jump to bookmark table\n"
         let help .= '" '. g:NERDTreeMapActivateNode .": open bookmark\n"
         let help .= '" '. g:NERDTreeMapPreview .": preview file\n"
         let help .= '" '. g:NERDTreeMapPreview .": find dir in tree\n"

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -98,6 +98,7 @@ endif
 
 "SECTION: Init variable calls for key mappings {{{2
 let g:NERDTreeMapCustomOpen      = get(g:, 'NERDTreeMapCustomOpen',      '<CR>')
+let g:NERDTreeMapJumpBookmarks   = get(g:, 'NERDTreeMapJumpBookmarks',   'b')
 let g:NERDTreeMapActivateNode    = get(g:, 'NERDTreeMapActivateNode',    'o')
 let g:NERDTreeMapChangeRoot      = get(g:, 'NERDTreeMapChangeRoot',      'C')
 let g:NERDTreeMapChdir           = get(g:, 'NERDTreeMapChdir',           'cd')


### PR DESCRIPTION
### Description of Changes
Closes #1304   <!-- Enter the issue number this PR addresses. If none, remove this line. -->

Adds the natural 'b' binding to jump directly to the bookmark table. This skips a lot of manual navigation to the bookmarks for users who want to use `NERDTree` as a way to quickly navigate to certain directories with the file explorer. 

---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
