### PR TITLE
Vim 9.0 menu patch

### DIFF
--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -46,7 +46,7 @@ function! s:MenuController.showMenu()
 
         " Redraw when Ctrl-C or Esc is received.
         if !l:done || self.selection ==# -1
-            redraw! | resize
+            redraw!
         endif
     endtry
 
@@ -172,6 +172,7 @@ endfunction
 function! s:MenuController._restoreOptions()
     let &cmdheight = self._oldCmdheight
     let &lazyredraw = self._oldLazyredraw
+    resize
 endfunction
 
 "FUNCTION: MenuController._cursorDown() {{{1

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -46,7 +46,7 @@ function! s:MenuController.showMenu()
 
         " Redraw when Ctrl-C or Esc is received.
         if !l:done || self.selection ==# -1
-            redraw!
+            redraw! | resize
         endif
     endtry
 


### PR DESCRIPTION
## EDIT:
### This is only open for historical reasons and to make it easier to find.
This PR is a hotfix for the issue mentioned in #1321.
There is a problem in the early versions of Vim9 which prevents some parts of NERDTree from restoring their original size after a temporary window/pane resize. This patch forces a manual resize so deal with this issue.
I suggest you update your Vim if you are experiencing this problem instead of using this patch.

**TL;DR** Just update your Vim!

### Description of Changes
Force resize after closing the menu to prevent issue [#1321](https://github.com/preservim/nerdtree/issues/1321)

---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
