### PR TITLE
New menu command: Change selected node permissions

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -45,6 +45,7 @@ call NERDTreeAddMenuItem({'text': (has('clipboard')?'copy (p)ath to clipboard':'
 
 if has('unix') || has('osx')
     call NERDTreeAddMenuItem({'text': '(l)ist the current node', 'shortcut': 'l', 'callback': 'NERDTreeListNode'})
+    call NERDTreeAddMenuItem({'text': '(C)hange node permissions', 'shortcut':'C', 'callback': 'NERDTreeChangePermissions'})
 else
     call NERDTreeAddMenuItem({'text': '(l)ist the current node', 'shortcut': 'l', 'callback': 'NERDTreeListNodeWin32'})
 endif
@@ -327,6 +328,29 @@ function! NERDTreeListNodeWin32()
                     \ strftime('%c', getftime(l:path)),
                     \ getfsize(l:path),
                     \ getfperm(l:path)))
+        return
+    endif
+
+    call nerdtree#echo('node not recognized')
+endfunction
+
+" FUNCTION: NERDTreeChangePermissions() {{{1
+function! NERDTreeChangePermissions()
+    let l:node = g:NERDTreeFileNode.GetSelected()
+    let l:prompt = "change node permissions: "
+    let l:newNodePerm = input(l:prompt)
+
+    if !empty(l:node)
+        let l:path = l:node.path.str()
+        let l:cmd = 'chmod ' .. newNodePerm .. ' ' .. path
+        let l:error = split(system(l:cmd), '\n')
+
+        if !empty(l:error)
+            call nerdtree#echo(l:error[0])
+        endif
+
+        call b:NERDTree.root.refresh()
+        call b:NERDTree.render()
         return
     endif
 


### PR DESCRIPTION
### Description of Changes

Adds a new option in the menu to change the selected node permissions. When invoking this menu option - m, C - it prompts the user for a new mode (i.e.: `+x`) and then it uses that input for executing `chown` in the selected node.

Does not work in Windows for now.

---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
