### PR TITLE
Fix [...] directories not showing children

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -278,6 +278,10 @@ function! s:TreeDirNode._glob(pattern, all)
     else
         let l:pathSpec = escape(fnamemodify(self.path.str({'format': 'Glob'}), ':.'), ',')
 
+        if nerdtree#runningWindows()
+            let l:pathSpec = substitute(l:pathSpec, "\\[\\(.*\\]\\)", "[[]\\1", "g")
+        endif
+
         " On Windows, the drive letter may be removed by "fnamemodify()".
         if nerdtree#runningWindows() && l:pathSpec[0] == nerdtree#slash()
             let l:pathSpec = self.path.drive . l:pathSpec


### PR DESCRIPTION
### Description of Changes

Correctly escape directories named `[<dir_name>]` on Windows. Per `:help wildcards`:

```
To avoid the special meaning of the wildcards prepend a backslash.  However,
on MS-Windows the backslash is a path separator and "path\[abc]" is still seen
as a wildcard when "[" is in the 'isfname' option.  A simple way to avoid this
is to use "path\[[]abc]", this matches the file "path\[abc]".
```

This fix simply implements this pattern for `TreeDirNode` `l:pathSpec`, and only on Windows - as I haven't seen any documentation showing this bug on other systems.

Before this change, children of directories with square-bracketed names would not be shown (see issues below for examples).

This is related to, but does not close necessarily vim/vim#12629, neovim/neovim#24233


---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
