### PR TITLE
Lazy Directory Refresh

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -774,6 +774,8 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeCustomOpenArgs|      A dictionary with values that control how a node
                             is opened with the |NERDTree-<CR>| key.
 
+|NERDTreeLazyDirRefresh|      Enables lazy directory refreshing (experimental)
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeSettingsDetails*
 
@@ -1304,6 +1306,18 @@ To open files and directories (creating a new NERDTree) in a new tab, >
 <
 To open a file always in the current tab, and expand directories in place, >
     {'file': {'reuse':'currenttab', 'where':'p', 'keepopen':1, 'stay':1}}
+<
+------------------------------------------------------------------------------
+                                                        *NERDTreeLazyDirRefresh*
+Values: 0 or 1
+Default: 0
+
+'experimental'
+
+If set to 1, the NERDTree will use lazy refresh on close directories whenever
+a refresh action is performed. Actual refresh happens when it is required.
+It happens on directory open and findNode functions.
+
 <
 ==============================================================================
 4. The NERDTree API                                                *NERDTreeAPI*

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -567,13 +567,15 @@ endfunction
 "
 " 0 == normal (default)
 " 1 == force
-" 2 == lazyRefresh
+" 2 == lazyRefresh (refreshes node only if lazyRefresh flag is set)
 "
 function! s:TreeDirNode.refresh(...)
     let l:mode = a:0 ? a:1 : 0
     call self.path.refresh(self.getNerdtree())
 
-    "if this node was ever opened, refresh its children
+    "if refresh is forced, refresh its children
+    "if this node is open, refresh its children
+    "if this node is flaged for lazyRefresh and lazyRefresh requested, refresh its children
     if l:mode == 1 || self.isOpen || (!empty(self.children) && !g:NERDTreeLazyDirRefresh) || (l:mode == 2 && self.lazyRefresh)
         let files = self._glob('*', 1) + self._glob('.*', 0)
         let newChildNodes = []
@@ -606,6 +608,7 @@ function! s:TreeDirNode.refresh(...)
             call nerdtree#echoWarning('some files could not be loaded into the NERD tree')
         endif
         let self.lazyRefresh = 0
+    " if this node is not empty and NERDTreeLazyDirRefresh is enable flag the node for lazyRefresh
     elseif g:NERDTreeLazyDirRefresh && !empty(self.children)
         let self.lazyRefresh = 1
     endif


### PR DESCRIPTION
### Description of Changes
Added a new feature for helping with the performance via lazy loading.
Right now NerdTree is keeping track of every directory that has ever been opened And will refresh them when a refresh happens via `NERDTreeMapRefresh`, This approach is perfect for small to medium code bases, But my day job forces me to work on substantial monolith repositories, It makes NerdTree very slow to use whenever you open a big directory. The initial caching process understandably takes time and by the look of the NerdTree structure it seems going full async is going to be very time-consuming as it is built before any vim-script async options and implementing asynchronous tree manipulation is going to need major refactoring.
So best solution for now is going to be doing optimization where it is possible, My first try to tackle this problem is lazy loading for directories. In this PR I've modified `TreeDirNode`'s `refresh` function so now it accepts an optional argument called `mode`, Mode can be one of these options:
```
    0 == normal (default when nothing passed)
    1 == force
    2 == lazyRefresh
```
The `normal` mode has identical behavior to the current revision of the NerdTree, the `force` mode will refresh the node no matter what state it has, and the `lazyRefresh` state will refresh the node only if its lazyRefresh flag has been set before.

Whenever a normal refresh is performed which means every old call of refresh, We check if `NerdTreeLazyDirRefresh` is set or not, If its set then we only perform refresh on already open directories, And mark closed directories for lazyRefresh, Then at any point which TreeDirNode's data is needed we perform refresh with mode `lazyRefresh`.

This way when you are working on a big project, Or even want to open a directory like `node_modules` containing many nested directories, After the initial caching which is going to be slow, You can browse the directory and close its tree afterward to regain your performance, Now if you perform a refresh on the root of project, Huge directory will only get marked for refresh next time you are going to open it Instead of doing it immediately.

### Potential problems
There may or may not be some usages of TreeDirNode which need its data updated but I haven't used lazyRefresh there, I haven't encountered any problems yet, But I don't use every functionality of NerdTree in my workflow and I don't have a deep knowledge of NerdTree codebase. Hence `experimental` flag is there in the documentation to warn people.

### Demonstration
Here is a short side-by-side video of the difference between this feature enable or disable.


https://github.com/preservim/nerdtree/assets/3788964/1e76f00c-ade3-437a-9ae7-c2b6f3a53282



---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
