### PR TITLE
Horizontal positioning for the `g:NERDTreeWinPos`

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1128,7 +1128,7 @@ setting is used.
 
 ------------------------------------------------------------------------------
                                                                 *NERDTreeWinPos*
-Values: "left" or "right"
+Values: "left", "right", "top" or "bottom"
 Default: "left".
 
 This setting is used to determine where NERDTree window is placed on the
@@ -1138,6 +1138,13 @@ This setting makes it possible to use two different explorer plugins
 simultaneously. For example, you could have the taglist plugin on the left of
 the window and the NERDTree on the right.
 
+When setting this variable to "top" or "bottom" make sure to also change the
+|NERDTreeWinSize| to a more reasonable size.
+
+For example:
+>
+    let g:NERDTreeWinSize = 15
+<
 ------------------------------------------------------------------------------
                                                                *NERDTreeWinSize*
 Values: a positive integer.

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -182,16 +182,17 @@ endfunction
 " Initialize the NERDTree window.  Open the window, size it properly, set all
 " local options, etc.
 function! s:Creator._createTreeWin()
-    let l:splitLocation = g:NERDTreeWinPos ==# 'left' ? 'topleft ' : 'botright '
+    let l:splitLocation = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'top' ? 'topleft ' : 'botright '
+    let l:splitDirection = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'right' ? 'vertical' : ''
     let l:splitSize = g:NERDTreeWinSize
 
     if !g:NERDTree.ExistsForTab()
         let t:NERDTreeBufName = self._nextBufferName()
-        silent! execute l:splitLocation . 'vertical ' . l:splitSize . ' new'
+        silent! execute l:splitLocation . l:splitDirection . ' ' . l:splitSize . ' new'
         silent! execute 'edit ' . t:NERDTreeBufName
-        silent! execute 'vertical resize '. l:splitSize
+        silent! execute l:splitDirection . ' resize '. l:splitSize
     else
-        silent! execute l:splitLocation . 'vertical ' . l:splitSize . ' split'
+        silent! execute l:splitLocation . l:splitDirection . ' ' . l:splitSize . ' split'
         silent! execute 'buffer ' . t:NERDTreeBufName
     endif
 


### PR DESCRIPTION
### Description of Changes
Closes #1361

Adds 2 extra options to `g:NERDTreeWinPos`, Now in addition to `left` and `right` it also accept `top` and `bottom`.
Uses the same `g:NERDTreeWinSize` to determine the height of the pane.

---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
