### PR TITLE
Added reveal functionality for Windows platform in fs_menu

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -24,7 +24,7 @@ call NERDTreeAddMenuItem({'text': '(m)ove the current node', 'shortcut': 'm', 'c
 call NERDTreeAddMenuItem({'text': '(d)elete the current node', 'shortcut': 'd', 'callback': 'NERDTreeDeleteNode'})
 
 if has('gui_mac') || has('gui_macvim') || has('mac')
-    call NERDTreeAddMenuItem({'text': '(r)eveal in Finder the current node', 'shortcut': 'r', 'callback': 'NERDTreeRevealInFinder'})
+    call NERDTreeAddMenuItem({'text': '(r)eveal the current node in the Finder', 'shortcut': 'r', 'callback': 'NERDTreeRevealInFinder'})
     call NERDTreeAddMenuItem({'text': '(o)pen the current node with system editor', 'shortcut': 'o', 'callback': 'NERDTreeExecuteFile'})
     call NERDTreeAddMenuItem({'text': '(q)uicklook the current node', 'shortcut': 'q', 'callback': 'NERDTreeQuickLook'})
 endif
@@ -35,6 +35,7 @@ if executable('xdg-open')
 endif
 
 if nerdtree#runningWindows()
+    call NERDTreeAddMenuItem({'text': '(r)eveal the current node in the Explorer', 'shortcut': 'r', 'callback': 'NERDTreeRevealInExplorer'})
     call NERDTreeAddMenuItem({'text': '(o)pen the current node with system editor', 'shortcut': 'o', 'callback': 'NERDTreeExecuteFileWindows'})
 endif
 
@@ -451,6 +452,21 @@ function! NERDTreeExecuteFileLinux()
     endif
 
     call system('xdg-open ' . shellescape(l:node.path.str()))
+endfunction
+
+" FUNCTION: NERDTreeRevealInExplorer() {{{1
+function! NERDTreeRevealInExplorer()
+    let l:node = g:NERDTreeFileNode.GetSelected()
+
+    if empty(l:node)
+        return
+    endif
+
+    if empty(l:node.parent)
+        return
+    endif
+
+    call system('cmd.exe /c explorer /select, ' . shellescape(l:node.path.str()))
 endfunction
 
 " FUNCTION: NERDTreeExecuteFileWindows() {{{1

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -523,10 +523,6 @@ function! NERDTreeRevealInExplorer()
         return
     endif
 
-    if empty(l:node.parent)
-        return
-    endif
-
     call system('cmd.exe /c explorer /select, ' . shellescape(l:node.path.str()))
 endfunction
 


### PR DESCRIPTION
### Description of Changes
Adds similar functionality to Linux and Mac platforms for revealing the selected node in the file browser(in the case of Windows It's `Windows Explorer`)


---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
