### PR TITLE
Added toggle for displaying symlink destination

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -719,6 +719,9 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeShowLineNumbers|     Tells the NERDTree whether to display line
                             numbers in the tree window.
 
+|NERDTreeShowSymlinkDest|     Tells the NERDTree whether to display symlinks
+                            destination path or display it as a normal node
+
 |NERDTreeSortOrder|           Tell the NERDTree how to sort the nodes in the
                             tree.
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -61,7 +61,8 @@ function! s:Path.cacheDisplayString() abort
         let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' {' . join(self._bookmarkNames) . '}'
     endif
 
-    if self.isSymLink
+    " Show symlink destination if instructed to
+    if self.isSymLink && g:NERDTreeShowSymlinkDest
         let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' -> ' . self.symLinkDest
     endif
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -52,6 +52,7 @@ let g:NERDTreeShowFiles             = get(g:, 'NERDTreeShowFiles',             1
 let g:NERDTreeShowHidden            = get(g:, 'NERDTreeShowHidden',            0)
 let g:NERDTreeShowLineNumbers       = get(g:, 'NERDTreeShowLineNumbers',       0)
 let g:NERDTreeSortDirs              = get(g:, 'NERDTreeSortDirs',              1)
+let g:NERDTreeShowSymlinkDest       = get(g:, 'NERDTreeShowSymlinkDest',       1)
 
 if !nerdtree#runningWindows() && !nerdtree#runningCygwin()
     let g:NERDTreeDirArrowExpandable  = get(g:, 'NERDTreeDirArrowExpandable',  '▸')


### PR DESCRIPTION
### Description of Changes
Added an option to settings for showing or hiding symlink destinations.
Note:
This actually hides the special highlighting for symlink, As its highlighting depends on the `->` mark being present and I've tried to reflect that in the documentation.
Changing this behavior may need changes to the way symlinks are represented so we can highlight them without the destination path being present.


---
### New Version Info

#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
