### PR TITLE
Case Sensitive Move Operation

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -673,6 +673,9 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 
 |NERDTreeAutoCenterThreshold| Controls the sensitivity of autocentering.
 
+|NERDTreeCaseInsensitiveFS|   Tells the NERDTree whether or not it is
+                            running in on a case sensitive file system.
+
 |NERDTreeCaseSensitiveSort|   Tells the NERDTree whether to be case
                             sensitive or not when sorting nodes.
 
@@ -808,6 +811,33 @@ Default: 3
 This setting controls the "sensitivity" of the NERDTree auto centering. See
 |NERDTreeAutoCenter| for details.
 
+------------------------------------------------------------------------------
+                                                     *NERDTreeCaseInsensitiveFS*
+Values: 0 or 1.
+Default: 0.
+
+By default, the NERDTree assumes it is running on a case-sensitive file
+system, With setting this option to 1 you can inform the NERDTree that
+it is running on a case-insensitive file system by doing so it will try
+to compensate for the potential issues that could happen because of it.
+
+Setting it to 1 by accident on a case-sensitive file system could case
+undesirable outcomes, For example, moving a file to another casing path
+could cause an overwrite without warning if the destination file already
+exists.
+
+If you are using your vim across multiple platforms, You can use a simple code
+like this in your configuration to set the default value based on the
+operating system(Keep in mind both macOS and Windows can have case sensitively
+in their file system and this automated approach isn't fool proof!) >
+ if nerdtree#runningWindows()
+     let g:NERDTreeCaseInsensitiveFS = 1
+ elseif has('gui_mac') || has('gui_macvim') || has('mac') || has('osx')
+     let g:NERDTreeCaseInsensitiveFS = 1
+ else
+     let g:NERDTreeCaseInsensitiveFS = 0
+ endif
+<
 ------------------------------------------------------------------------------
                                                      *NERDTreeCaseSensitiveSort*
 Values: 0 or 1.

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -148,18 +148,38 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
         let quotedFileName = fnameescape(a:newNodeName)
         let editStr = g:NERDTreePath.New(a:newNodeName).str({'format': 'Edit'})
     endif
-    " 1. ensure that a new buffer is loaded
-    call nerdtree#exec('badd ' . quotedFileName, 0)
-    " 2. ensure that all windows which display the just deleted filename
-    " display a buffer for a new filename.
     let s:originalTabNumber = tabpagenr()
     let s:originalWindowNumber = winnr()
-    call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . a:bufNum . " | exec ':e! " . editStr . "' | endif", 0)
-    call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
-    call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
-    " 3. We don't need a previous buffer anymore
+    let l:tempBufferName = 'NERDTreeRenameTempBuffer'
+
+    " 1. swap deleted file buffer with a temporary one
+    " this step is needed to compensate for case insensitive filesystems
+
+    " 1.1. create an intermediate(temporary) buffer
+    call nerdtree#exec('badd ' . l:tempBufferName, 0)
+    let l:tempBufNum = bufnr(l:tempBufferName)
+    " 1.2. ensure that all windows which display the just deleted filename
+    " display the new temp buffer.
+    call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . a:bufNum . " | exec ':e! " . l:tempBufferName . "' | endif", 0)
+    " 1.3. We don't need the deleted file buffer anymore
     try
         call nerdtree#exec('confirm bwipeout ' . a:bufNum, 0)
+    catch
+        " This happens when answering Cancel if confirmation is needed. Do nothing.
+    endtry
+
+    " 2. swap temporary buffer with the new filename buffer
+    " 2.1. create the actual new file buffer
+    call nerdtree#exec('badd ' . quotedFileName, 0)
+
+    " 2.2. ensure that all windows which display the temporary buffer
+    " display a buffer for the new filename.
+    call nerdtree#exec('tabdo windo if winbufnr(0) ==# ' . l:tempBufNum . " | exec ':e! " . editStr . "' | endif", 0)
+    call nerdtree#exec('tabnext ' . s:originalTabNumber, 1)
+    call nerdtree#exec(s:originalWindowNumber . 'wincmd w', 1)
+    " 2.3. We don't need the temporary buffer anymore
+    try
+        call nerdtree#exec('confirm bwipeout ' . l:tempBufNum, 0)
     catch
         " This happens when answering Cancel if confirmation is needed. Do nothing.
     endtry
@@ -205,6 +225,15 @@ function! NERDTreeMoveNode()
     let prompt = s:inputPrompt('move')
     let newNodePath = input(prompt, curNode.path.str(), 'file')
     while filereadable(newNodePath)
+        " allow renames with different casing when g:NERDTreeCaseInsensitiveFS
+        " is enabled even tho Vim says the destination already exists,
+        " It will result in an undesired overwrite if set to true by accident
+        if g:NERDTreeCaseInsensitiveFS && !(curNode.path.str() ==# newNodePath)
+            if tolower(curNode.path.str()) ==# tolower(newNodePath)
+                break
+            endif
+        endif
+
         call nerdtree#echoWarning('This destination already exists. Try again.')
         let newNodePath = substitute(input(prompt, curNode.path.str(), 'file'), '\(^\s*\|\s*$\)', '', 'g')
     endwhile

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -29,6 +29,7 @@ set cpoptions&vim
 "SECTION: Initialize variable calls and other random constants {{{2
 let g:NERDTreeAutoCenter            = get(g:, 'NERDTreeAutoCenter',            1)
 let g:NERDTreeAutoCenterThreshold   = get(g:, 'NERDTreeAutoCenterThreshold',   3)
+let g:NERDTreeCaseInsensitiveFS     = get(g:, 'NERDTreeCaseInsensitiveFS',     0)
 let g:NERDTreeCaseSensitiveSort     = get(g:, 'NERDTreeCaseSensitiveSort',     0)
 let g:NERDTreeNaturalSort           = get(g:, 'NERDTreeNaturalSort',           0)
 let g:NERDTreeSortHiddenFirst       = get(g:, 'NERDTreeSortHiddenFirst',       1)


### PR DESCRIPTION
### Description of Changes
Closes #1373 and potentially many unresolved issues on the subject of case insensitivity.
In this commit, I've introduced a new option called `NERDTreeCaseInsensitiveFS` which could also be used in the future to resolve similar issues in other places.
Until now the Move Operation used to check if the destination path already exists or not, On case-insensitive file systems this check fails if the user wants to move the file to a location with a different casing (for example moving/renaming `foo.bar` to `FOO.BAR`) as both paths point to the same file. With this new option, we can have an extra check to see whether or not the new destination is the same path in a different casing, and if that's the case we can ignore this false positive check.
With this new change came a wrong artifact, After the rename operation we check if an open buffer to this path exists or not.
Then we will point every window to that buffer to a new buffer for the new file path, vim doesn't acknowledge the new file path if it already has one open for the old casing file, I've used a temp buffer to compensate for this issue. Now we first redirect every window to a temp buffer, close the old buffer, and point windows looking at the temp buffer to this newly created one.
This part is written very clearly and has a lot of comments explaining each step of the process in the code itself.

---
### New Version Info
@alerque Sadly we skipped a few commits versioning, I would like to make a PR adding versions / CHANGELOG to the old merged PRs.
We can either block this PR until we fix the change log, or go ahead and merge it and give it a change log in the fix PR.
#### Author's Instructions
- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
    ```bash
    git checkout master
    git pull
    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
    ```
