### PR TITLE
Update GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,18 +5,3 @@ Closes #    <!-- Enter the issue number this PR addresses. If none, remove this 
 ---
 ### New Version Info
 
-#### Author's Instructions
-- [ ] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
-    - `MAJOR` version when you make incompatible API changes
-    - `MINOR` version when you add functionality in a backwards-compatible manner
-    - `PATCH` version when you make backwards-compatible bug fixes
-- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
-#### Collaborator's Instructions
-- [ ] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
-- [ ] After merging, tag the commit using these (Mac-compatible) bash commands:
-    ```bash
-    git checkout master
-    git pull
-    sed -n "$(grep -n -m2 '####' CHANGELOG.md | cut -f1 -d: | sed 'N;s/\n/,/')p" CHANGELOG.md | sed '$d'
-    git tag -a $(read -p "Tag Name: " tag;echo $tag) -m"$(git show --quiet --pretty=%s)";git push origin --tags
-    ```


### PR DESCRIPTION
### Description of Changes
Removed old Instructions,
Since we no longer release a tag for each commit, instructions to create them are unnecessary. As for the version number it is on the maintainer to suggest the correct version number and manage the merge priorities so why bother confusing the PR submiter with this?
But proposing the new version changes is on the author of the change so I suggest keeping that section of the template.