### PR TITLE
Add split explorer to NERDTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.0
-- **.2**: Add split explorer capability to NERDTREE (msibal6) [#1389](https://github.com/preservim/nerdtree/pull/1389)
 - **.1**:
     - Fix NERDTreeFind to handle directory case sensitivity. (dangibson) [#1387](https://github.com/preservim/nerdtree/pull/1387)
     - New Show file lines toggle. (hsnks100) [#1384](https://github.com/preservim/nerdtree/pull/1384)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.0
-- **.2**: Add split explorer capability to NERDTREE (msibal6) [#1368](https://github.com/preservim/nerdtree/pull/1368)
+- **.2**: Add split explorer capability to NERDTREE (msibal6) [#1389](https://github.com/preservim/nerdtree/pull/1389)
 - **.1**:
     - Fix NERDTreeFind to handle directory case sensitivity. (dangibson) [#1387](https://github.com/preservim/nerdtree/pull/1387)
     - New Show file lines toggle. (hsnks100) [#1384](https://github.com/preservim/nerdtree/pull/1384)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.0
-- **.2**: Add split explorer capability to NERDTREE (tempoz) [#1237](https://github.com/preservim/nerdtree/pull/1237)
+- **.2**: Add split explorer capability to NERDTREE (msibal6) [#1368](https://github.com/preservim/nerdtree/pull/1368)
 - **.1**:
     - Fix NERDTreeFind to handle directory case sensitivity. (dangibson) [#1387](https://github.com/preservim/nerdtree/pull/1387)
     - New Show file lines toggle. (hsnks100) [#1384](https://github.com/preservim/nerdtree/pull/1384)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.0
+- **.2**: Add split explorer capability to NERDTREE (tempoz) [#1237](https://github.com/preservim/nerdtree/pull/1237)
 - **.1**:
     - Fix NERDTreeFind to handle directory case sensitivity. (dangibson) [#1387](https://github.com/preservim/nerdtree/pull/1387)
     - New Show file lines toggle. (hsnks100) [#1384](https://github.com/preservim/nerdtree/pull/1384)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -642,7 +642,7 @@ endfunction
 function! nerdtree#ui_glue#setupCommands() abort
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
-    command! -n=? -complete=dir -bar NERDTreeExplorer :call g:NERDTreeCreator.CreateWindowTree('<args>')
+    command! -n=? -complete=dir -bar NERDTreeExplorer :call g:NERDTreeCreator.CreateExplorerTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=0 -bar NERDTreeMirror call g:NERDTreeCreator.CreateMirror()

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -642,7 +642,7 @@ endfunction
 function! nerdtree#ui_glue#setupCommands() abort
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
-    command! -n=? -complete=dir -bar NERDTreeExplorer :call g:NERDTreeCreator.CreateExplorerTree('<args>')
+    command! -n=? -complete=dir -bar NERDTreeExplore :call g:NERDTreeCreator.CreateExploreTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=0 -bar NERDTreeMirror call g:NERDTreeCreator.CreateMirror()

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -642,6 +642,7 @@ endfunction
 function! nerdtree#ui_glue#setupCommands() abort
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
+    command! -n=? -complete=dir -bar NERDTreeExplorer :call g:NERDTreeCreator.CreateWindowTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')
     command! -n=0 -bar NERDTreeMirror call g:NERDTreeCreator.CreateMirror()

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -40,6 +40,13 @@ endfunction
 
 " FUNCTION: s:Creator.CreateExplorerTree(dir) {{{1
 function! s:Creator.CreateExplorerTree(dir)
+    try
+        let path = g:NERDTreePath.New(a:dir)
+    catch /^NERDTree.InvalidArgumentsError/
+        call nerdtree#echo('Invalid directory name:' . a:dir)
+        return
+    endtry
+
     let creator = s:Creator.New()
     if getbufinfo('%')[0].changed
         let l:splitLocation = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'top' ? 'topleft ' : 'botright '

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -38,8 +38,8 @@ function! s:Creator.BufNamePrefix()
     return 'NERD_tree_'
 endfunction
 
-" FUNCTION: s:Creator.CreateExplorerTree(dir) {{{1
-function! s:Creator.CreateExplorerTree(dir)
+" FUNCTION: s:Creator.CreateExploreTree(dir) {{{1
+function! s:Creator.CreateExploreTree(dir)
     try
         let path = g:NERDTreePath.New(a:dir)
     catch /^NERDTree.InvalidArgumentsError/
@@ -48,12 +48,17 @@ function! s:Creator.CreateExplorerTree(dir)
     endtry
 
     let creator = s:Creator.New()
-    if getbufinfo('%')[0].changed
+    if getbufinfo('%')[0].changed && !&hidden && !&autowriteall
         let l:splitLocation = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'top' ? 'topleft ' : 'botright '
         let l:splitDirection = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'right' ? 'vertical' : ''
+        silent! execute l:splitLocation . l:splitDirection . ' new'
+    else
+        silent! execute 'enew'
     endif
-    silent! execute l:splitLocation . l:splitDirection . ' new'
+
     call creator.createWindowTree(a:dir)
+    "we want windowTree buffer to disappear after moving to any other buffer
+    setlocal bufhidden=wipe
 endfunction
 
 " FUNCTION: s:Creator.CreateTabTree(a:name) {{{1

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -38,6 +38,17 @@ function! s:Creator.BufNamePrefix()
     return 'NERD_tree_'
 endfunction
 
+" FUNCTION: s:Creator.CreateExplorerTree(dir) {{{1
+function! s:Creator.CreateExplorerTree(dir)
+    let creator = s:Creator.New()
+    if getbufinfo('%')[0].changed
+        let l:splitLocation = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'top' ? 'topleft ' : 'botright '
+        let l:splitDirection = g:NERDTreeWinPos ==# 'left' || g:NERDTreeWinPos ==# 'right' ? 'vertical' : ''
+    endif
+    silent! execute l:splitLocation . l:splitDirection . ' new'
+    call creator.createWindowTree(a:dir)
+endfunction
+
 " FUNCTION: s:Creator.CreateTabTree(a:name) {{{1
 function! s:Creator.CreateTabTree(name)
     let creator = s:Creator.New()


### PR DESCRIPTION
### Description of Changes
This adds a new user defined command `NERDTreeExplorer` to a split explorer for a directory. 

### Motivation
I toggle NERDTree often after opening my file, so I tend to already use it more as an explorer than a drawer. I saw [#1237 for adding split explorer](https://github.com/preservim/nerdtree/pull/1237) had a pending action item, so I decided to implement it since it was a simple add when implemented as a command.

I also want to give a quick shout out to @rzvxa for taking the initiative to handling the majority of these most recent PRs since Phil's retirement. It's cool to see a tool live on even when it is very robust and there is not a bunch of changes happening. Thanks to you and everybody for continuing to support this tool and preventing bit rot into it! 😁 

