### PR TITLE
Fix typo in nerdtree.txt

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -605,7 +605,7 @@ Toggles whether the bookmarks table is displayed.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-L*
 Default key: L
-Map setting: *NERDTreeMapToggleFileLiness*
+Map setting: *NERDTreeMapToggleFileLines*
 Applies to: no restrictions.
 
 Toggles whether the number of lines in files is displayed.


### PR DESCRIPTION
### Description of Changes
Fix map setting typo in doc/nerdtree.txt.
