### PR TITLE
fix: session restore for nerdtree buffers.

### DIFF
--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -118,7 +118,7 @@ function! s:Creator.createWindowTree(dir)
 
     "we need a unique name for each window tree buffer to ensure they are
     "all independent
-    exec g:NERDTreeCreatePrefix . ' edit ' . self._nextBufferName()
+    exec g:NERDTreeCreatePrefix . ' edit ' . self._nextBufferName('win')
 
     call self._createNERDTree(path, 'window')
     let b:NERDTree._previousBuf = bufnr(previousBuf)
@@ -210,7 +210,7 @@ function! s:Creator._createTreeWin()
     let l:splitSize = g:NERDTreeWinSize
 
     if !g:NERDTree.ExistsForTab()
-        let t:NERDTreeBufName = self._nextBufferName()
+        let t:NERDTreeBufName = self._nextBufferName('tab')
         silent! execute l:splitLocation . l:splitDirection . ' ' . l:splitSize . ' new'
         silent! execute 'edit ' . t:NERDTreeBufName
         silent! execute l:splitDirection . ' resize '. l:splitSize
@@ -244,10 +244,17 @@ function! s:Creator.New()
     return newCreator
 endfunction
 
-" FUNCTION: s:Creator._nextBufferName() {{{1
-" returns the buffer name for the next nerd tree
-function! s:Creator._nextBufferName()
-    let name = s:Creator.BufNamePrefix() . self._nextBufferNumber()
+" FUNCTION: s:Creator._nextBufferName(type='') {{{1
+" gets a buffer type of either 'tab' or 'win', defaults to unknown
+" returns the buffer name for the next nerd tree of such type.
+function! s:Creator._nextBufferName(type='')
+    let name = s:Creator.BufNamePrefix()
+    if a:type == 'tab'
+        let name = name . 'tab_'
+    elseif a:type == 'win'
+        let name = name . 'win_'
+    endif
+    let name = name . self._nextBufferNumber()
     return name
 endfunction
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -245,13 +245,18 @@ function! s:Creator.New()
 endfunction
 
 " FUNCTION: s:Creator._nextBufferName(type='') {{{1
-" gets a buffer type of either 'tab' or 'win', defaults to unknown
+" gets an optional buffer type of either 'tab' or 'win'.
 " returns the buffer name for the next nerd tree of such type.
-function! s:Creator._nextBufferName(type='')
+function! s:Creator._nextBufferName(...)
+    if a:0 > 0
+        let type = a:1
+    else
+        let type = ''
+    end
     let name = s:Creator.BufNamePrefix()
-    if a:type == 'tab'
+    if type == 'tab'
         let name = name . 'tab_'
-    elseif a:type == 'win'
+    elseif type == 'win'
         let name = name . 'win_'
     endif
     let name = name . self._nextBufferNumber()

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -254,9 +254,9 @@ function! s:Creator._nextBufferName(...)
         let type = ''
     end
     let name = s:Creator.BufNamePrefix()
-    if type == 'tab'
+    if type ==# 'tab'
         let name = name . 'tab_'
-    elseif type == 'win'
+    elseif type ==# 'win'
         let name = name . 'win_'
     endif
     let name = name . self._nextBufferNumber()

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -151,7 +151,7 @@ call nerdtree#ui_glue#setupCommands()
 "============================================================
 augroup NERDTree
     "Save the cursor position whenever we close the nerd tree
-    exec 'autocmd BufLeave,WinLeave '. g:NERDTreeCreator.BufNamePrefix() .'* if g:NERDTree.IsOpen() | call b:NERDTree.ui.saveScreenState() | endif'
+    exec 'autocmd BufLeave,WinLeave '. g:NERDTreeCreator.BufNamePrefix() .'* call nerdtree#onBufLeave()'
 
     "disallow insert mode in the NERDTree
     exec 'autocmd BufEnter,WinEnter '. g:NERDTreeCreator.BufNamePrefix() .'* stopinsert'


### PR DESCRIPTION
### Description of Changes
Closes #1397


---
### New Version Info

This PR adds a new naming scheme for the NERDTree buffers, instead of having `NERD_tree_[num]` for all NERDTree buffers now we use `NERD_tree_tab_[num]` for tab buffers and `NERD_tree_win_[num]` for window buffers, This is then used during the restoration of a previously saved session to detect the type of given buffers and rescue them.