### PR TITLE
fix: GetWinNum regex pattern.

### DIFF
--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -144,7 +144,7 @@ function! s:NERDTree.GetWinNum()
 
     " If WindowTree, there is no t:NERDTreeBufName variable. Search all windows.
     for w in range(1,winnr('$'))
-        if bufname(winbufnr(w)) =~# '^' . g:NERDTreeCreator.BufNamePrefix() . '\d\+$'
+        if bufname(winbufnr(w)) =~# '^' . g:NERDTreeCreator.BufNamePrefix() . 'win_\d\+$'
             return w
         endif
     endfor


### PR DESCRIPTION
### Description of Changes
Closes #1408 


---
### New Version Info

Fixes the regex pattern in the `GetWinNum` to detect the new NERDTree buffer names correctly.