### PR TITLE
chore: bump version to 7.1.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **.3**:
     - docs: update FAQ snippets containing quit command. (rzvxa) [#1417](https://github.com/preservim/nerdtree/pull/1417)
     - feat: jump to bookmark table shortcut. (ds2606, rzvxa) [#1394](https://github.com/preservim/nerdtree/pull/1394)
+    - fix: typo in docs for show file lines setting. (lothardp) [#1426](https://github.com/preservim/nerdtree/pull/1426)
 - **.2**:
     - fix: GetWinNum regex pattern. (rzvxa) [#1409](https://github.com/preservim/nerdtree/pull/1409)
     - fix: session restore for nerdtree buffers. (rzvxa) [#1405](https://github.com/preservim/nerdtree/pull/1405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.1
-- **.3**: feat: jump to bookmark table shortcut. (ds2606, rzvxa) [#1394](https://github.com/preservim/nerdtree/pull/1394)
+- **.3**:
+    - docs: update FAQ snippets containing quit command. (rzvxa) [#1417](https://github.com/preservim/nerdtree/pull/1417)
+    - feat: jump to bookmark table shortcut. (ds2606, rzvxa) [#1394](https://github.com/preservim/nerdtree/pull/1394)
 - **.2**:
     - fix: GetWinNum regex pattern. (rzvxa) [#1409](https://github.com/preservim/nerdtree/pull/1409)
     - fix: session restore for nerdtree buffers. (rzvxa) [#1405](https://github.com/preservim/nerdtree/pull/1405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
             - Pull Request Title n (PR Author) [PR Number](Link to PR)
 -->
 #### 7.1
+- **.3**: feat: jump to bookmark table shortcut. (ds2606, rzvxa) [#1394](https://github.com/preservim/nerdtree/pull/1394)
 - **.2**:
     - fix: GetWinNum regex pattern. (rzvxa) [#1409](https://github.com/preservim/nerdtree/pull/1409)
     - fix: session restore for nerdtree buffers. (rzvxa) [#1405](https://github.com/preservim/nerdtree/pull/1405)


### PR DESCRIPTION
### New Version Info

#### 7.1
- **.3**:
    - docs: update FAQ snippets containing quit command. (rzvxa) [#1417](https://github.com/preservim/nerdtree/pull/1417)
    - feat: jump to bookmark table shortcut. (ds2606, rzvxa) [#1394](https://github.com/preservim/nerdtree/pull/1394)
    - fix: typo in docs for show file lines setting. (lothardp) [#1426](https://github.com/preservim/nerdtree/pull/1426)