### PR TITLE
fix: typo in docs for show file lines setting

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1073,7 +1073,7 @@ mapping and is useful for drastically shrinking the tree when you are
 navigating to a different part of the tree.
 
 ------------------------------------------------------------------------------
-                                                        *NERDTreeShowFilesLines*
+                                                             *NERDTreeFileLines*
 Values: 0 or 1.
 Default: 0.
 
@@ -1083,8 +1083,8 @@ file.
 This setting can be toggled dynamically, per tree, with the |NERDTree-FL|
 mapping.
 Use one of the follow lines for this setting: >
-    let NERDTreeShowFilesLines=0
-    let NERDTreeShowFilesLines=1
+    let NERDTreeFileLines=0
+    let NERDTreeFileLines=1
 <
 ------------------------------------------------------------------------------
                                                             *NERDTreeShowHidden*


### PR DESCRIPTION
### Description of Changes

Just a typo fix in the docs.

The `NERDTreeShowFilesLines` setting doesn't work, and it makes sense because it's not read anywhere in the code. After some looking around I found that the right one is `NERDTreeFileLines` (as shown in the README also).

In this PR I just fix that typo in the docs so it is consistent.

---
### New Version Info

