### PR TITLE
Add option for relative numbers

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -731,6 +731,9 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeShowLineNumbers|     Tells the NERDTree whether to display line
                             numbers in the tree window.
 
+|NERDTreeShowRelLineNumbers|  Tells the NERDTree whether to display relative
+			    line numbers in the tree window.
+
 |NERDTreeSortOrder|           Tell the NERDTree how to sort the nodes in the
                             tree.
 
@@ -1106,6 +1109,16 @@ This setting tells vim whether to display line numbers for the NERDTree
 window.  Use one of the follow lines for this setting: >
     let NERDTreeShowLineNumbers=0
     let NERDTreeShowLineNumbers=1
+<
+------------------------------------------------------------------------------
+                                                    *NERDTreeShowRelLineNumbers*
+Values: 0 or 1.
+Default: 0.
+
+This setting tells vim whether to display relative line numbers for the NERDTree
+window.  Use one of the follow lines for this setting: >
+    let NERDTreeShowRelLineNumbers=0
+    let NERDTreeShowRelLineNumbers=1
 <
 ------------------------------------------------------------------------------
                                                              *NERDTreeSortOrder*

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -344,6 +344,8 @@ function! s:Creator._setCommonBufOptions()
 
     if g:NERDTreeShowLineNumbers
         setlocal number
+    elseif g:NERDTreeShowRelLineNumbers
+        setlocal relativenumber
     else
         setlocal nonumber
         if v:version >= 703

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -52,6 +52,7 @@ let g:NERDTreeShowBookmarks         = get(g:, 'NERDTreeShowBookmarks',         0
 let g:NERDTreeShowFiles             = get(g:, 'NERDTreeShowFiles',             1)
 let g:NERDTreeShowHidden            = get(g:, 'NERDTreeShowHidden',            0)
 let g:NERDTreeShowLineNumbers       = get(g:, 'NERDTreeShowLineNumbers',       0)
+let g:NERDTreeShowRelLineNumbers    = get(g:, 'NERDTreeShowRelLineNumbers',    0)
 let g:NERDTreeSortDirs              = get(g:, 'NERDTreeSortDirs',              1)
 let g:NERDTreeFileLines             = get(g:, 'NERDTreeFileLines',             0)
 


### PR DESCRIPTION
### Description of Changes

Additional variable for relative line numbers and correspondent documentation.

---
### New Version Info

Additional option to show the line number relative to the line with the cursor in front of  each line. Relative line numbers help you use the count you can precede some vertical motion commands with, without  having to calculate it yourself.