### PR TITLE
NERDTree is not notifying listeners on new file creation and child transplanting

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -591,6 +591,7 @@ function! s:TreeDirNode.refresh()
                     let newNode = g:NERDTreeFileNode.New(path, self.getNerdtree())
                     let newNode.parent = self
                     call add(newChildNodes, newNode)
+                    call g:NERDTreePathNotifier.NotifyListeners('init', newNode.path, newNode.getNerdtree(), {})
                 endif
             catch /^NERDTree.\(InvalidArguments\|InvalidFiletype\)Error/
                 let invalidFilesFound += 1
@@ -715,6 +716,7 @@ function! s:TreeDirNode.transplantChild(newNode)
             break
         endif
     endfor
+    call self.refresh()
 endfunction
 
 " vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
The update fixes the issue appearing as a missing devicon for a new file or for a child node of a former root, when moving up the tree.

Screenshot of the issue, when refreshing (r) the tree after the new file has been created:

&nbsp;&nbsp;&nbsp;<img src="https://github.com/user-attachments/assets/8d7b4bfb-c4db-42ba-834f-149680ceeda0" width="36%"/>

Screenshot of the issue, when moving up (u) the tree:

&nbsp;&nbsp;&nbsp;<img src="https://github.com/user-attachments/assets/cfe07880-db20-4971-a2a3-d90ec223a94d" width="30%">
