### PR TITLE
Add wincolor and highlight group

### DIFF
--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -341,6 +341,7 @@ function! s:Creator._setCommonBufOptions()
     setlocal nolist
     setlocal nospell
     setlocal nowrap
+    setlocal wincolor=NERDTreeWinColor
 
     if g:NERDTreeShowLineNumbers
         setlocal number

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -91,6 +91,7 @@ hi def link NERDTreeIgnore ignore
 hi def link NERDTreeRO WarningMsg
 hi def link NERDTreeBookmark Statement
 hi def link NERDTreeFlags Number
+hi def link NERDTreeWinColor Normal
 
 hi def link NERDTreeCurrentNode Search
 


### PR DESCRIPTION
### Description of Changes

This PR adds a new highlight group `NERDTreeWinColor` and sets `wincolor=NERDTreeWinColor` in the `nerdtree` buffer, see [wincolor](https://vimhelp.org/options.txt.html#%27wincolor%27).

This will allow themes to override the background of the nerdtree window. The highlight group is linked to `Normal` by default.



