### PR TITLE
feat: add NERDTreeReverseSort option for reverse alphabetical sorting

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -114,14 +114,14 @@ function! nerdtree#compareNodePaths(p1, p2) abort
         " integer type is the lesser.
         if type(sortKey1[i]) == type(sortKey2[i])
             if sortKey1[i] <# sortKey2[i]
-                return - 1
+                return g:NERDTreeReverseSort ? 1 : -1
             elseif sortKey1[i] ># sortKey2[i]
-                return 1
+                return g:NERDTreeReverseSort ? -1 : 1
             endif
         elseif type(sortKey1[i]) == type(0)
-            return -1
+            return g:NERDTreeReverseSort ? 1 : -1
         elseif type(sortKey2[i]) == type(0)
-            return 1
+            return g:NERDTreeReverseSort ? -1 : 1
         endif
         let i += 1
     endwhile
@@ -129,9 +129,9 @@ function! nerdtree#compareNodePaths(p1, p2) abort
     " Keys are identical upto common length.
     " The key which has smaller chunks is the lesser one.
     if len(sortKey1) < len(sortKey2)
-        return -1
+        return g:NERDTreeReverseSort ? 1 : -1
     elseif len(sortKey1) > len(sortKey2)
-        return 1
+        return g:NERDTreeReverseSort ? -1 : 1
     else
         return 0
     endif

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -691,6 +691,9 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeNaturalSort|         Tells the NERDTree whether to use natural sort
                             order or not when sorting nodes.
 
+|NERDTreeReverseSort|         Tells the NERDTree whether to sort nodes in
+                            reverse alphabetical order.
+
 |NERDTreeSortHiddenFirst|     Tells the NERDTree whether to take the dot at
                             the beginning of the hidden file names into
                             account when sorting nodes.
@@ -1158,6 +1161,18 @@ Examples: >
    timestamp, oldest first.
 6. Files and directories matching 'foo' first, followed by other directories,
    then all other files. Each section of files is sorted by file extension.
+
+------------------------------------------------------------------------------
+                                                         *NERDTreeReverseSort*
+Values: 0 or 1.
+Default: 0
+
+If set to 1, the NERDTree will sort nodes in reverse alphabetical order within
+each group defined by |NERDTreeSortOrder|. This applies to all levels of the
+tree.
+
+Example: >
+    let NERDTreeReverseSort=1
 
 ------------------------------------------------------------------------------
                                                             *NERDTreeStatusline*

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -69,6 +69,7 @@ let g:NERDTreeCascadeSingleChildDir     = get(g:, 'NERDTreeCascadeSingleChildDir
 
 let g:NERDTreeSortOrder    = get(g:, 'NERDTreeSortOrder', ['\/$', '*', '\.swp$', '\.bak$', '\~$'])
 let g:NERDTreeOldSortOrder = []
+let g:NERDTreeReverseSort  = get(g:, 'NERDTreeReverseSort',  0)
 
 let g:NERDTreeGlyphReadOnly = get(g:, 'NERDTreeGlyphReadOnly', 'RO')
 


### PR DESCRIPTION
### Description of Changes

This PR adds a new configuration option `g:NERDTreeReverseSort` that allows users to sort NERDTree nodes in reverse alphabetical order instead of the default alphabetical order.

Users who prefer reverse alphabetical sorting (e.g., to see files starting with later letters first, or for specific workflow preferences) currently have no built-in way to achieve this in NERDTree. I found there are many cases that it is more 'ergonomic'.

Also it does not hurt any existing behavior if not set any configuration.

Closes #1162 (though... it is already closed 😉 )